### PR TITLE
Convert locked to 'yes' or 'no'

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -54,7 +54,7 @@ class User
         $this->username = $userInfo[self::USERNAME] ?? null;
         $this->email = $userInfo[self::EMAIL] ?? null;
         $this->active = $userInfo[self::ACTIVE] ?? null;
-        $this->locked = $userInfo[self::LOCKED] ?? null;
+        $this->setLocked($userInfo[self::LOCKED] ?? null);
         
         if (empty($this->employeeId)) {
             throw new InvalidArgumentException('Employee ID cannot be empty.', 1493733219);
@@ -64,6 +64,21 @@ class User
     public function __toString()
     {
         return \json_encode($this->toArray(), JSON_PRETTY_PRINT);
+    }
+    
+    public function setLocked($input)
+    {
+        if ($input === null) {
+            return;
+        }
+        
+        $lowercasedInput = strtolower(trim($input));
+        
+        if (in_array($lowercasedInput, [false, 'false', 'no'])) {
+            $this->locked = 'no';
+        } else {
+            $this->locked = 'yes';
+        }
     }
     
     /**

--- a/application/features/behat.yml
+++ b/application/features/behat.yml
@@ -9,6 +9,9 @@ default:
         sync_features:
             paths:    [ %paths.base%/../features/sync.feature ]
             contexts: [ Sil\Idp\IdSync\Behat\Context\SyncContext ]
+        user_features:
+            paths:    [ %paths.base%/../features/user.feature ]
+            contexts: [ Sil\Idp\IdSync\Behat\Context\UserContext ]
         webhook_features:
             paths:    [ %paths.base%/../features/webhook.feature ]
             contexts: [ Sil\Idp\IdSync\Behat\Context\WebhookContext ]

--- a/application/features/bootstrap/UserContext.php
+++ b/application/features/bootstrap/UserContext.php
@@ -1,0 +1,91 @@
+<?php
+namespace Sil\Idp\IdSync\Behat\Context;
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
+use Sil\Idp\IdSync\common\models\User;
+
+/**
+ * Defines application features from the specific context.
+ */
+class UserContext implements Context
+{
+    /** @var User */
+    protected $user;
+    
+    /** @var array */
+    protected $result;
+    
+    protected function createUserWith($field, $value)
+    {
+        return new User(array_merge([
+            // Start with default values for required fields:
+            'employee_id' => '123'
+        ], [
+            // Overwrite with given value field/value:
+            $field => $value,
+        ]));
+    }
+    
+    /**
+     * @Given I create a User with a :field value of ':input'
+     */
+    public function iCreateAUserWithAValueOf($field, $input)
+    {
+        $this->user = $this->createUserWith($field, $input);
+    }
+
+    /**
+     * @When I get the info from that User
+     */
+    public function iGetTheInfoFromThatUser()
+    {
+        $this->result = $this->user->toArray();
+    }
+
+    /**
+     * @Then the :field value should be ':expected'
+     */
+    public function theValueShouldBe($field, $expected)
+    {
+        $actual = $this->result[$field];
+        Assert::assertSame($expected, $actual, sprintf(
+            "Expected: %s\nActual: %s",
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+
+    /**
+     * @Then the :field value should be null
+     */
+    public function theValueShouldBeNull($field)
+    {
+        Assert::assertArrayNotHasKey($field, $this->result);
+    }
+
+    /**
+     * @Given I create a User with a :field value of false
+     */
+    public function iCreateAUserWithAValueOfFalse($field)
+    {
+        $this->user = $this->createUserWith($field, false);
+    }
+
+    /**
+     * @Given I create a User with a :field value of true
+     */
+    public function iCreateAUserWithAValueOfTrue($field)
+    {
+        $this->user = $this->createUserWith($field, true);
+    }
+
+    /**
+     * @Given I create a User with a :field value of null
+     */
+    public function iCreateAUserWithAValueOfNull($field)
+    {
+        $this->user = $this->createUserWith($field, null);
+    }
+}

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -1,0 +1,21 @@
+
+Feature: Standardizing user info
+
+  Scenario Outline: Sanitizing input values
+    Given I create a User with a <field> value of <input>
+    When I get the info from that User
+    Then the <field> value should be <output>
+
+    Examples:
+      | field  | input   | output |
+      | locked | 'no'    | 'no'   |
+      | locked | 'false' | 'no'   |
+      | locked | 'False' | 'no'   |
+      | locked | 'FALSE' | 'no'   |
+      | locked | false   | 'no'   |
+      | locked | 'yes'   | 'yes'  |
+      | locked | 'true'  | 'yes'  |
+      | locked | 'True'  | 'yes'  |
+      | locked | 'TRUE'  | 'yes'  |
+      | locked | true    | 'yes'  |
+      | locked | null    | null   |


### PR DESCRIPTION
Our ID Store is apparently returning `'locked': 'false'` rather than `'no'`. This helps handle that.