### PR TITLE
Prevent ID Sync from changing too many users at a time

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -74,5 +74,6 @@ return [
             'emailFrom' => Env::get('MAILER_USERNAME'),
             'organizationName' => $idpName,
         ],
+        'syncSafetyCutoff' => Env::get('SYNC_SAFETY_CUTOFF'),
     ],
 ];

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -316,9 +316,10 @@ class Synchronizer
             $errorMessage = sprintf(
                 'This sync was aborted because it would have deactivated %s of '
                 . 'the %s active users found in ID Broker, which is above our '
-                . 'safety threshold of %s%%.',
+                . 'safety threshold of %s (%s%%).',
                 count($employeeIdsToDeactivate),
                 $numActiveUsersInBroker,
+                $deactivationSafetyThreshold,
                 ($maxDeactivationsPercent * 100)
             );
             $this->logger->error($errorMessage);

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -16,6 +16,7 @@ use yii\helpers\ArrayHelper;
 class Synchronizer
 {
     /** @var float */
+    const MIN_NUM_CHANGES_ALLOWED = 10;
     const SAFETY_CUTOFF_DEFAULT = 0.15;
     
     public $dateTimeFormat = 'n/j/y g:ia T';
@@ -346,7 +347,10 @@ class Synchronizer
             }
         }
         
-        $numChangesAllowed = ceil($numActiveUsersInBroker * $this->safetyCutoff);
+        $numChangesAllowed = max(
+            ceil($numActiveUsersInBroker * $this->safetyCutoff),
+            self::MIN_NUM_CHANGES_ALLOWED
+        );
         
         if (count($employeeIdsToDeactivate) > $numChangesAllowed) {
             $errorMessage = sprintf(

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -397,6 +397,14 @@ class Synchronizer
             );
         }
         
+        /**
+         * NOTE: If we begin intelligently comparing users found in both places
+         * and only updating those that need it, then we could limit updates to
+         * the safety cutoff as well. For now, we try to update all users found
+         * to exist in both places, so for a full sync that will almost always
+         * be above the safety cutoff.
+         */
+        
         if (count($employeeIdsToDeactivate) > $numChangesAllowed) {
             $this->abortSync(
                 'deactivate',

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -195,7 +195,7 @@ class Synchronizer
                 return $carry + 1;
             }
             return $carry;
-        });
+        }, 0);
     }
     
     /**

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -387,6 +387,16 @@ class Synchronizer
             self::MIN_NUM_CHANGES_ALLOWED
         );
         
+        if (count($usersToAdd) > $numChangesAllowed) {
+            $this->abortSync(
+                'create',
+                count($usersToAdd),
+                $numChangesAllowed,
+                $numActiveUsersInBroker,
+                1501165932
+            );
+        }
+        
         if (count($employeeIdsToDeactivate) > $numChangesAllowed) {
             $this->abortSync(
                 'deactivate',

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -286,9 +286,9 @@ class Synchronizer
      */
     protected function getAllIdBrokerUsersByEmployeeId($fields = null)
     {
-        if ( ! in_array(User::EMPLOYEE_ID, $fields)) {
+        if (is_array($fields) && ! in_array(User::EMPLOYEE_ID, $fields)) {
             throw new InvalidArgumentException(sprintf(
-                'The list of fields must include %s. Given list: %s',
+                'The list of fields, if provided, must include %s. Given list: %s',
                 User::EMPLOYEE_ID,
                 join(', ', $fields)
             ), 1501181580);

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -286,6 +286,14 @@ class Synchronizer
      */
     protected function getAllIdBrokerUsersByEmployeeId($fields = null)
     {
+        if ( ! in_array(User::EMPLOYEE_ID, $fields)) {
+            throw new InvalidArgumentException(sprintf(
+                'The list of fields must include %s. Given list: %s',
+                User::EMPLOYEE_ID,
+                join(', ', $fields)
+            ), 1501181580);
+        }
+        
         $rawList = $this->idBroker->listUsers($fields);
         $usersByEmployeeId = [];
         

--- a/application/common/traits/SyncProvider.php
+++ b/application/common/traits/SyncProvider.php
@@ -49,6 +49,14 @@ trait SyncProvider
             );
         }
         
-        return new Synchronizer($idStore, $idBroker, $logger, $notifier);
+        $syncSafetyCutoff = Yii::$app->params['syncSafetyCutoff'];
+        
+        return new Synchronizer(
+            $idStore,
+            $idBroker,
+            $logger,
+            $notifier,
+            $syncSafetyCutoff
+        );
     }
 }

--- a/application/features/behat.yml
+++ b/application/features/behat.yml
@@ -9,6 +9,9 @@ default:
         insite_integration_features:
             paths:    [ %paths.base%/../features/id-store-integration.feature ]
             contexts: [ Sil\Idp\IdSync\Behat\Context\InsiteIntegrationContext ]
+        safety_cutoff_features:
+            paths:    [ %paths.base%/../features/safetyCutoff.feature ]
+            contexts: [ Sil\Idp\IdSync\Behat\Context\SafetyCutoffContext ]
         sync_features:
             paths:    [ %paths.base%/../features/sync.feature ]
             contexts: [ Sil\Idp\IdSync\Behat\Context\SyncContext ]

--- a/application/features/bootstrap/SafetyCutoffContext.php
+++ b/application/features/bootstrap/SafetyCutoffContext.php
@@ -1,0 +1,167 @@
+<?php
+namespace Sil\Idp\IdSync\Behat\Context;
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Behat\Context\Context;
+use Exception;
+use PHPUnit\Framework\Assert;
+use Psr\Log\LoggerInterface;
+use Sil\Idp\IdSync\common\sync\Synchronizer;
+use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdBroker;
+use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdStore;
+use Sil\Idp\IdSync\common\components\notify\ConsoleNotifier;
+use Sil\Idp\IdSync\common\interfaces\IdBrokerInterface;
+use Sil\Idp\IdSync\common\interfaces\IdStoreInterface;
+use Sil\Idp\IdSync\common\interfaces\NotifierInterface;
+use Sil\Idp\IdSync\common\models\User;
+use Sil\Psr3Adapters\Psr3ConsoleLogger;
+use yii\helpers\Json;
+
+/**
+ * Defines application features from the specific context.
+ */
+class SafetyCutoffContext implements Context
+{
+    /** @var Exception */
+    private $exceptionThrown = null;
+    
+    /** @var IdBrokerInterface */
+    private $idBroker;
+    
+    /** @var IdStoreInterface */
+    private $idStore;
+    
+    /** @var LoggerInterface */
+    protected $logger;
+    
+    /** @var NotifierInterface */
+    protected $notifier;
+    
+    private $tempMaxDeactivationsPercent = null;
+    
+    /**
+     * @Then an exception SHOULD have been thrown
+     */
+    public function anExceptionShouldHaveBeenThrown()
+    {
+        Assert::assertNotNull(
+            $this->exceptionThrown,
+            "An exception should have been thrown, but wasn't"
+        );
+    }
+    
+    /**
+     * @Then an exception should NOT have been thrown
+     */
+    public function anExceptionShouldNotHaveBeenThrown()
+    {
+        $possibleException = $this->exceptionThrown ?? new Exception();
+        Assert::assertNotInstanceOf(Exception::class, $this->exceptionThrown, sprintf(
+            'Unexpected exception (%s): %s',
+            $possibleException->getCode(),
+            $possibleException->getMessage()
+        ));
+    }
+    
+    protected function createSynchronizer()
+    {
+        return new Synchronizer(
+            $this->idStore,
+            $this->idBroker,
+            $this->logger,
+            $this->notifier
+        );
+    }
+    
+    /**
+     * @param array $activeUsers
+     * @return FakeIdStore
+     */
+    protected function getFakeIdStore(array $activeUsers = [])
+    {
+        return new FakeIdStore($activeUsers);
+    }
+    
+    /**
+     * @When I sync all the users from the ID Store to the ID Broker
+     */
+    public function iSyncAllTheUsersFromTheIdStoreToTheIdBroker()
+    {
+        try {
+            $synchronizer = $this->createSynchronizer();
+            if ($this->tempMaxDeactivationsPercent !== null) {
+                $synchronizer->syncAll($this->tempMaxDeactivationsPercent);
+            } else {
+                $synchronizer->syncAll();
+            }
+        } catch (Exception $e) {
+            $this->exceptionThrown = $e;
+        }
+    }
+    
+    /**
+     * @Given the cutoff for deactivations is :number
+     */
+    public function theCutoffForDeactivationsIs($number)
+    {
+        $this->tempMaxDeactivationsPercent = $number;
+    }
+    
+    /**
+     * @Given :number users are active in the ID Broker
+     */
+    public function usersAreActiveInTheIdBroker($number)
+    {
+        $idBrokerUsers = [];
+        for ($i = 1; $i <= $number; $i++) {
+            $tempEmployeeId = 10000 + $i;
+            $idBrokerUsers[$tempEmployeeId] = [
+                User::EMPLOYEE_ID => (string)$tempEmployeeId,
+                User::DISPLAY_NAME => 'Person ' . $i,
+                User::USERNAME => 'person_' . $i,
+                User::FIRST_NAME => 'Person',
+                User::LAST_NAME => (string)$i,
+                User::EMAIL => 'person_' . $i . '@example.com',
+                User::ACTIVE => 'yes',
+            ];
+        }
+        
+        $this->idBroker = new FakeIdBroker($idBrokerUsers);
+    }
+    
+    /**
+     * @Given (only) :number users are active in the ID Store
+     */
+    public function usersAreActiveInTheIdStore($number)
+    {
+        $activeIdStoreUsers = [];
+        for ($i = 1; $i <= $number; $i++) {
+            $tempEmployeeId = 10000 + $i;
+            $activeIdStoreUsers[$tempEmployeeId] = [
+                'employeenumber' => (string)$tempEmployeeId,
+                'displayname' => 'Person ' . $i,
+                'username' => 'person_' . $i,
+                'firstname' => 'Person',
+                'lastname' => (string)$i,
+                'email' => 'person_' . $i . '@example.com',
+            ];
+        }
+        $this->idStore = $this->getFakeIdStore($activeIdStoreUsers);
+    }
+    
+    /**
+     * @Given :number users are active in the ID Store and are inactive in the ID Broker
+     */
+    public function usersAreActiveInTheIdStoreAndAreInactiveInTheIdBroker($number)
+    {
+        $this->usersAreActiveInTheIdStore($number);
+        
+        $idBrokerUsers = [];
+        foreach ($this->idStore->getAllActiveUsers() as $user) {
+            $user->active = 'no';
+            $idBrokerUsers[$user->employeeId] = $user->toArray();
+        }
+        $this->idBroker = new FakeIdBroker($idBrokerUsers);
+    }
+}

--- a/application/features/bootstrap/SafetyCutoffContext.php
+++ b/application/features/bootstrap/SafetyCutoffContext.php
@@ -149,4 +149,47 @@ class SafetyCutoffContext implements Context
     {
         $this->safetyCutoff = $value;
     }
+
+    /**
+     * @Given running a full sync would create :numToCreate users
+     */
+    public function runningAFullSyncWouldCreateUsers($numToCreate)
+    {
+        Assert::assertNotEmpty(
+            $this->idBroker,
+            'Set up the ID Broker before using this step.'
+        );
+        
+        $usersFromBroker = $this->idBroker->listUsers();
+        $activeIdStoreUsers = [];
+        
+        // Add all users from ID Broker to ID Store.
+        foreach ($usersFromBroker as $user) {
+            $activeIdStoreUsers[$user->employeeId] = [
+                'employeenumber' => (string)$user->employeeId,
+                'displayname' => $user->displayName,
+                'username' => $user->username,
+                'firstname' => $user->firstName,
+                'lastname' => $user->lastName,
+                'email' => $user->email,
+            ];
+        }
+        
+        // Add $numToCreate more users to ID Store.
+        $numInBroker = count($usersFromBroker);
+        $numToHaveInStore = $numInBroker + $numToCreate;
+        for ($i = $numInBroker; $i < $numToHaveInStore; $i++) {
+            $tempEmployeeId = 10000 + $i;
+            $activeIdStoreUsers[$tempEmployeeId] = [
+                'employeenumber' => (string)$tempEmployeeId,
+                'displayname' => 'Person ' . $i,
+                'username' => 'person_' . $i,
+                'firstname' => 'Person',
+                'lastname' => (string)$i,
+                'email' => 'person_' . $i . '@example.com',
+            ];
+        }
+        
+        $this->idStore = new FakeIdStore($activeIdStoreUsers);
+    }
 }

--- a/application/features/bootstrap/SafetyCutoffContext.php
+++ b/application/features/bootstrap/SafetyCutoffContext.php
@@ -184,7 +184,7 @@ class SafetyCutoffContext implements Context
         // Add $numToCreate more users to ID Store.
         $numInBroker = count($usersFromBroker);
         $numToHaveInStore = $numInBroker + $numToCreate;
-        for ($i = $numInBroker; $i < $numToHaveInStore; $i++) {
+        for ($i = $numInBroker; $i <= $numToHaveInStore; $i++) {
             $tempEmployeeId = 10000 + $i;
             $activeIdStoreUsers[$tempEmployeeId] = [
                 'employeenumber' => (string)$tempEmployeeId,

--- a/application/features/bootstrap/SafetyCutoffContext.php
+++ b/application/features/bootstrap/SafetyCutoffContext.php
@@ -41,6 +41,12 @@ class SafetyCutoffContext implements Context
     /** @var float|null */
     private $safetyCutoff = null;
     
+    public function __construct()
+    {
+        $this->logger = new Psr3ConsoleLogger();
+        $this->notifier = new ConsoleNotifier();
+    }
+    
     /**
      * @Then an exception SHOULD have been thrown
      */

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -440,11 +440,11 @@ class SyncContext implements Context
     }
 
     /**
-     * @Given the cutoff for deactivations is :number%
+     * @Given the cutoff for deactivations is :number
      */
     public function theCutoffForDeactivationsIs($number)
     {
-        $this->tempMaxDeactivationsPercent = $number / 100;
+        $this->tempMaxDeactivationsPercent = $number;
     }
 
     /**

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -40,8 +40,6 @@ class SyncContext implements Context
     
     private $tempEmployeeId;
     
-    private $tempMaxDeactivationsPercent = null;
-    
     private $tempUserChanges = [];
     
     public function __construct()
@@ -232,11 +230,7 @@ class SyncContext implements Context
     {
         try {
             $synchronizer = $this->createSynchronizer();
-            if ($this->tempMaxDeactivationsPercent !== null) {
-                $synchronizer->syncAll($this->tempMaxDeactivationsPercent);
-            } else {
-                $synchronizer->syncAll();
-            }
+            $synchronizer->syncAll();
         } catch (Exception $e) {
             $this->exceptionThrown = $e;
         }
@@ -327,28 +321,6 @@ class SyncContext implements Context
     }
 
     /**
-     * @Given :number users are active in the ID Broker
-     */
-    public function usersAreActiveInTheIdBroker($number)
-    {
-        $idBrokerUsers = [];
-        for ($i = 1; $i <= $number; $i++) {
-            $tempEmployeeId = 10000 + $i;
-            $idBrokerUsers[$tempEmployeeId] = [
-                User::EMPLOYEE_ID => (string)$tempEmployeeId,
-                User::DISPLAY_NAME => 'Person ' . $i,
-                User::USERNAME => 'person_' . $i,
-                User::FIRST_NAME => 'Person',
-                User::LAST_NAME => (string)$i,
-                User::EMAIL => 'person_' . $i . '@example.com',
-                User::ACTIVE => 'yes',
-            ];
-        }
-        
-        $this->idBroker = new FakeIdBroker($idBrokerUsers);
-    }
-
-    /**
      * @Given (only) :number users are active in the ID Store
      */
     public function usersAreActiveInTheIdStore($number)
@@ -427,26 +399,7 @@ class SyncContext implements Context
         }
         $this->idBroker = new FakeIdBroker($idBrokerUsers);
     }
-
-    /**
-     * @Then an exception SHOULD have been thrown
-     */
-    public function anExceptionShouldHaveBeenThrown()
-    {
-        Assert::assertNotNull(
-            $this->exceptionThrown,
-            "An exception should have been thrown, but wasn't"
-        );
-    }
-
-    /**
-     * @Given the cutoff for deactivations is :number
-     */
-    public function theCutoffForDeactivationsIs($number)
-    {
-        $this->tempMaxDeactivationsPercent = $number;
-    }
-
+    
     /**
      * @Then an exception should NOT have been thrown
      */

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -1,7 +1,6 @@
 <?php
 namespace Sil\Idp\IdSync\Behat\Context;
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Context\Context;
 use Exception;

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -1,12 +1,11 @@
 <?php
 namespace Sil\Idp\IdSync\Behat\Context;
 
-use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
 use Exception;
 use PHPUnit\Framework\Assert;
 use Psr\Log\LoggerInterface;
-use Sil\Idp\IdSync\common\sync\Synchronizer;
 use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdBroker;
 use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdStore;
 use Sil\Idp\IdSync\common\components\notify\ConsoleNotifier;
@@ -14,6 +13,7 @@ use Sil\Idp\IdSync\common\interfaces\IdBrokerInterface;
 use Sil\Idp\IdSync\common\interfaces\IdStoreInterface;
 use Sil\Idp\IdSync\common\interfaces\NotifierInterface;
 use Sil\Idp\IdSync\common\models\User;
+use Sil\Idp\IdSync\common\sync\Synchronizer;
 use Sil\Psr3Adapters\Psr3ConsoleLogger;
 use yii\helpers\Json;
 

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -433,7 +433,10 @@ class SyncContext implements Context
      */
     public function anExceptionShouldHaveBeenThrown()
     {
-        Assert::assertNotNull($this->exceptionThrown);
+        Assert::assertNotNull(
+            $this->exceptionThrown,
+            "An exception should have been thrown, but wasn't"
+        );
     }
 
     /**

--- a/application/features/safetyCutoff.feature
+++ b/application/features/safetyCutoff.feature
@@ -1,0 +1,34 @@
+
+Feature: Preventing too many changes at once to protect against iffy data.
+
+  Scenario Outline: Preventing too many user-deactivations at a time
+    Given <brokerHas> users are active in the ID Broker
+      And only <storeOnlyHas> users are active in the ID Store
+      And the cutoff for deactivations is <cutoffPercent>
+    When I sync all the users from the ID Store to the ID Broker
+    Then an exception <exceptionOrNot> have been thrown
+
+    Examples:
+      | brokerHas | storeOnlyHas | cutoffPercent | exceptionOrNot |
+      |  10       |  10          |   0.15        |  should NOT    |
+      |  10       |   9          |   0.15        |  should NOT    |
+      |  10       |   8          |   0.15        |  should NOT    |
+      |  10       |   7          |   0.15        |  SHOULD        |
+      |  10       |   6          |   0.15        |  SHOULD        |
+      |  10       |   5          |   0.15        |  SHOULD        |
+      |  10       |   4          |   0.15        |  SHOULD        |
+      |  10       |   3          |   0.15        |  SHOULD        |
+      |  10       |   2          |   0.15        |  SHOULD        |
+      |  10       |   1          |   0.15        |  SHOULD        |
+      |  10       |   0          |   0.15        |  SHOULD        |
+      |  10       |   5          |   0.60        |  should NOT    |
+      |  10       |   4          |   0.60        |  should NOT    |
+      |  10       |   3          |   0.60        |  SHOULD        |
+      |  10       |   2          |   0.60        |  SHOULD        |
+      |   2       |   2          |  -1           |  SHOULD        |
+      |   2       |   2          |   0           |  should NOT    |
+      |   2       |   2          |   1           |  should NOT    |
+      |   2       |   2          |   0.99        |  should NOT    |
+      |   2       |   2          |   1.00        |  should NOT    |
+      |   2       |   2          |   1.01        |  SHOULD        |
+      |   2       |   2          |   abcd        |  SHOULD        |

--- a/application/features/safetyCutoff.feature
+++ b/application/features/safetyCutoff.feature
@@ -2,33 +2,34 @@
 Feature: Preventing too many changes at once to protect against iffy data.
 
   Scenario Outline: Preventing too many user-deactivations at a time
-    Given <brokerHas> users are active in the ID Broker
-      And only <storeOnlyHas> users are active in the ID Store
-      And the cutoff for deactivations is <cutoffPercent>
+    Given <numInBroker> users are active in the ID Broker
+      And running a full sync would deactivate <numToDeactivate> users
+      And the safety cutoff is <safetyCutoff>
     When I sync all the users from the ID Store to the ID Broker
     Then an exception <exceptionOrNot> have been thrown
 
     Examples:
-      | brokerHas | storeOnlyHas | cutoffPercent | exceptionOrNot |
-      |  10       |  10          |   0.15        |  should NOT    |
-      |  10       |   9          |   0.15        |  should NOT    |
-      |  10       |   8          |   0.15        |  should NOT    |
-      |  10       |   7          |   0.15        |  SHOULD        |
-      |  10       |   6          |   0.15        |  SHOULD        |
-      |  10       |   5          |   0.15        |  SHOULD        |
-      |  10       |   4          |   0.15        |  SHOULD        |
-      |  10       |   3          |   0.15        |  SHOULD        |
-      |  10       |   2          |   0.15        |  SHOULD        |
-      |  10       |   1          |   0.15        |  SHOULD        |
-      |  10       |   0          |   0.15        |  SHOULD        |
-      |  10       |   5          |   0.60        |  should NOT    |
-      |  10       |   4          |   0.60        |  should NOT    |
-      |  10       |   3          |   0.60        |  SHOULD        |
-      |  10       |   2          |   0.60        |  SHOULD        |
-      |   2       |   2          |  -1           |  SHOULD        |
-      |   2       |   2          |   0           |  should NOT    |
-      |   2       |   2          |   1           |  should NOT    |
-      |   2       |   2          |   0.99        |  should NOT    |
-      |   2       |   2          |   1.00        |  should NOT    |
-      |   2       |   2          |   1.01        |  SHOULD        |
-      |   2       |   2          |   abcd        |  SHOULD        |
+      | numInBroker | numToDeactivate | safetyCutoff | exceptionOrNot |
+      |    10       |      0          |     0.15     |  should NOT    |
+      |    10       |      1          |     0.15     |  should NOT    |
+      |    10       |      2          |     0.15     |  should NOT    |
+      |    10       |      3          |     0.15     |  SHOULD        |
+      |    10       |      4          |     0.15     |  SHOULD        |
+      |    10       |      5          |     0.15     |  SHOULD        |
+      |    10       |      6          |     0.15     |  SHOULD        |
+      |    10       |      7          |     0.15     |  SHOULD        |
+      |    10       |      8          |     0.15     |  SHOULD        |
+      |    10       |      9          |     0.15     |  SHOULD        |
+      |    10       |     10          |     0.15     |  SHOULD        |
+      |    10       |      5          |     0.60     |  should NOT    |
+      |    10       |      6          |     0.60     |  should NOT    |
+      |    10       |      7          |     0.60     |  SHOULD        |
+      |    10       |      8          |     0.60     |  SHOULD        |
+      |     2       |      0          |    -1        |  SHOULD        |
+      |     2       |      0          |     0        |  should NOT    |
+      |     2       |      0          |     1        |  should NOT    |
+      |     2       |      0          |     0.99     |  should NOT    |
+      |     2       |      0          |     1.00     |  should NOT    |
+      |     2       |      0          |     1.01     |  SHOULD        |
+      |     2       |      0          |     abcd     |  SHOULD        |
+

--- a/application/features/safetyCutoff.feature
+++ b/application/features/safetyCutoff.feature
@@ -10,21 +10,23 @@ Feature: Preventing too many changes at once to protect against iffy data.
 
     Examples:
       | activeInBroker | numToDeactivate | safetyCutoff | exceptionOrNot |
-      |       10       |      0          |     0.15     |  should NOT    |
-      |       10       |      1          |     0.15     |  should NOT    |
-      |       10       |      2          |     0.15     |  should NOT    |
-      |       10       |      3          |     0.15     |  SHOULD        |
-      |       10       |      4          |     0.15     |  SHOULD        |
-      |       10       |      5          |     0.15     |  SHOULD        |
-      |       10       |      6          |     0.15     |  SHOULD        |
-      |       10       |      7          |     0.15     |  SHOULD        |
-      |       10       |      8          |     0.15     |  SHOULD        |
-      |       10       |      9          |     0.15     |  SHOULD        |
-      |       10       |     10          |     0.15     |  SHOULD        |
-      |       10       |      5          |     0.60     |  should NOT    |
-      |       10       |      6          |     0.60     |  should NOT    |
-      |       10       |      7          |     0.60     |  SHOULD        |
-      |       10       |      8          |     0.60     |  SHOULD        |
+      |      100       |      0          |     0.15     |  should NOT    |
+      |      100       |     10          |     0.15     |  should NOT    |
+      |      100       |     15          |     0.15     |  should NOT    |
+      |      100       |     16          |     0.15     |  SHOULD        |
+      |      100       |     20          |     0.15     |  SHOULD        |
+      |      100       |     30          |     0.15     |  SHOULD        |
+      |      100       |     40          |     0.15     |  SHOULD        |
+      |      100       |     50          |     0.15     |  SHOULD        |
+      |      100       |     60          |     0.15     |  SHOULD        |
+      |      100       |     70          |     0.15     |  SHOULD        |
+      |      100       |     80          |     0.15     |  SHOULD        |
+      |      100       |     90          |     0.15     |  SHOULD        |
+      |      100       |    100          |     0.15     |  SHOULD        |
+      |      100       |     59          |     0.60     |  should NOT    |
+      |      100       |     60          |     0.60     |  should NOT    |
+      |      100       |     61          |     0.60     |  SHOULD        |
+      |      100       |     62          |     0.60     |  SHOULD        |
       |        2       |      0          |    -1        |  SHOULD        |
       |        2       |      0          |     0        |  should NOT    |
       |        2       |      0          |     1        |  should NOT    |
@@ -42,15 +44,17 @@ Feature: Preventing too many changes at once to protect against iffy data.
 
     Examples:
       | activeInBroker | numToCreate | safetyCutoff | exceptionOrNot |
-      |       10       |      0      |     0.15     |  should NOT    |
-      |       10       |      1      |     0.15     |  should NOT    |
-      |       10       |      2      |     0.15     |  should NOT    |
-      |       10       |      3      |     0.15     |  SHOULD        |
-      |       10       |      4      |     0.15     |  SHOULD        |
-      |       10       |      5      |     0.15     |  SHOULD        |
-      |       10       |      6      |     0.15     |  SHOULD        |
-      |       10       |      7      |     0.15     |  SHOULD        |
-      |       10       |      8      |     0.15     |  SHOULD        |
-      |       10       |      9      |     0.15     |  SHOULD        |
-      |       10       |     10      |     0.15     |  SHOULD        |
+      |      100       |      0      |     0.15     |  should NOT    |
+      |      100       |     10      |     0.15     |  should NOT    |
+      |      100       |     15      |     0.15     |  should NOT    |
+      |      100       |     16      |     0.15     |  SHOULD        |
+      |      100       |     20      |     0.15     |  SHOULD        |
+      |      100       |     30      |     0.15     |  SHOULD        |
+      |      100       |     40      |     0.15     |  SHOULD        |
+      |      100       |     50      |     0.15     |  SHOULD        |
+      |      100       |     60      |     0.15     |  SHOULD        |
+      |      100       |     70      |     0.15     |  SHOULD        |
+      |      100       |     80      |     0.15     |  SHOULD        |
+      |      100       |     90      |     0.15     |  SHOULD        |
+      |      100       |    100      |     0.15     |  SHOULD        |
 

--- a/application/features/safetyCutoff.feature
+++ b/application/features/safetyCutoff.feature
@@ -1,7 +1,7 @@
 
 Feature: Preventing too many changes at once to protect against iffy data.
 
-  Scenario Outline: Preventing too many user-deactivations at a time
+  Scenario Outline: Preventing too many user-deactivations in a full sync
     Given <activeInBroker> users are active in the ID Broker
       And running a full sync would deactivate <numToDeactivate> users
       And the safety cutoff is <safetyCutoff>
@@ -35,7 +35,7 @@ Feature: Preventing too many changes at once to protect against iffy data.
       |        2       |      0          |     1.01     |  SHOULD        |
       |        2       |      0          |     abcd     |  SHOULD        |
 
-  Scenario Outline: Preventing too many user-creations at a time
+  Scenario Outline: Preventing too many user-creations in a full sync
     Given <activeInBroker> users are active in the ID Broker
       And running a full sync would create <numToCreate> users
       And the safety cutoff is <safetyCutoff>
@@ -57,4 +57,26 @@ Feature: Preventing too many changes at once to protect against iffy data.
       |      100       |     80      |     0.15     |  SHOULD        |
       |      100       |     90      |     0.15     |  SHOULD        |
       |      100       |    100      |     0.15     |  SHOULD        |
+
+
+  Scenario Outline: Preventing too many combined changes in an incremental sync
+    Given <activeInBroker> users are active in the ID Broker
+      And an incremental sync would add <add>, update <update>, and deactivate <deact> users
+      And the safety cutoff is <safetyCutoff>
+    When I run an incremental sync
+    Then an exception <exceptionOrNot> have been thrown
+
+    Examples:
+      | activeInBroker | add | update | deact | safetyCutoff | exceptionOrNot |
+      |      100       |   0 |     0  |    0  |     0.15     |  should NOT    |
+      |      100       |  15 |     0  |    0  |     0.15     |  should NOT    |
+      |      100       |  16 |     0  |    0  |     0.15     |  SHOULD        |
+      |      100       |   0 |    15  |    0  |     0.15     |  should NOT    |
+      |      100       |   0 |    16  |    0  |     0.15     |  SHOULD        |
+      |      100       |   0 |     0  |   15  |     0.15     |  should NOT    |
+      |      100       |   0 |     0  |   16  |     0.15     |  SHOULD        |
+      |      100       |   5 |     5  |    5  |     0.15     |  should NOT    |
+      |      100       |   6 |     5  |    5  |     0.15     |  SHOULD        |
+      |      100       |   5 |     6  |    5  |     0.15     |  SHOULD        |
+      |      100       |   5 |     5  |    6  |     0.15     |  SHOULD        |
 

--- a/application/features/safetyCutoff.feature
+++ b/application/features/safetyCutoff.feature
@@ -2,34 +2,34 @@
 Feature: Preventing too many changes at once to protect against iffy data.
 
   Scenario Outline: Preventing too many user-deactivations at a time
-    Given <numInBroker> users are active in the ID Broker
+    Given <activeInBroker> users are active in the ID Broker
       And running a full sync would deactivate <numToDeactivate> users
       And the safety cutoff is <safetyCutoff>
     When I sync all the users from the ID Store to the ID Broker
     Then an exception <exceptionOrNot> have been thrown
 
     Examples:
-      | numInBroker | numToDeactivate | safetyCutoff | exceptionOrNot |
-      |    10       |      0          |     0.15     |  should NOT    |
-      |    10       |      1          |     0.15     |  should NOT    |
-      |    10       |      2          |     0.15     |  should NOT    |
-      |    10       |      3          |     0.15     |  SHOULD        |
-      |    10       |      4          |     0.15     |  SHOULD        |
-      |    10       |      5          |     0.15     |  SHOULD        |
-      |    10       |      6          |     0.15     |  SHOULD        |
-      |    10       |      7          |     0.15     |  SHOULD        |
-      |    10       |      8          |     0.15     |  SHOULD        |
-      |    10       |      9          |     0.15     |  SHOULD        |
-      |    10       |     10          |     0.15     |  SHOULD        |
-      |    10       |      5          |     0.60     |  should NOT    |
-      |    10       |      6          |     0.60     |  should NOT    |
-      |    10       |      7          |     0.60     |  SHOULD        |
-      |    10       |      8          |     0.60     |  SHOULD        |
-      |     2       |      0          |    -1        |  SHOULD        |
-      |     2       |      0          |     0        |  should NOT    |
-      |     2       |      0          |     1        |  should NOT    |
-      |     2       |      0          |     0.99     |  should NOT    |
-      |     2       |      0          |     1.00     |  should NOT    |
-      |     2       |      0          |     1.01     |  SHOULD        |
-      |     2       |      0          |     abcd     |  SHOULD        |
+      | activeInBroker | numToDeactivate | safetyCutoff | exceptionOrNot |
+      |       10       |      0          |     0.15     |  should NOT    |
+      |       10       |      1          |     0.15     |  should NOT    |
+      |       10       |      2          |     0.15     |  should NOT    |
+      |       10       |      3          |     0.15     |  SHOULD        |
+      |       10       |      4          |     0.15     |  SHOULD        |
+      |       10       |      5          |     0.15     |  SHOULD        |
+      |       10       |      6          |     0.15     |  SHOULD        |
+      |       10       |      7          |     0.15     |  SHOULD        |
+      |       10       |      8          |     0.15     |  SHOULD        |
+      |       10       |      9          |     0.15     |  SHOULD        |
+      |       10       |     10          |     0.15     |  SHOULD        |
+      |       10       |      5          |     0.60     |  should NOT    |
+      |       10       |      6          |     0.60     |  should NOT    |
+      |       10       |      7          |     0.60     |  SHOULD        |
+      |       10       |      8          |     0.60     |  SHOULD        |
+      |        2       |      0          |    -1        |  SHOULD        |
+      |        2       |      0          |     0        |  should NOT    |
+      |        2       |      0          |     1        |  should NOT    |
+      |        2       |      0          |     0.99     |  should NOT    |
+      |        2       |      0          |     1.00     |  should NOT    |
+      |        2       |      0          |     1.01     |  SHOULD        |
+      |        2       |      0          |     abcd     |  SHOULD        |
 

--- a/application/features/safetyCutoff.feature
+++ b/application/features/safetyCutoff.feature
@@ -33,3 +33,24 @@ Feature: Preventing too many changes at once to protect against iffy data.
       |        2       |      0          |     1.01     |  SHOULD        |
       |        2       |      0          |     abcd     |  SHOULD        |
 
+  Scenario Outline: Preventing too many user-creations at a time
+    Given <activeInBroker> users are active in the ID Broker
+      And running a full sync would create <numToCreate> users
+      And the safety cutoff is <safetyCutoff>
+    When I sync all the users from the ID Store to the ID Broker
+    Then an exception <exceptionOrNot> have been thrown
+
+    Examples:
+      | activeInBroker | numToCreate | safetyCutoff | exceptionOrNot |
+      |       10       |      0      |     0.15     |  should NOT    |
+      |       10       |      1      |     0.15     |  should NOT    |
+      |       10       |      2      |     0.15     |  should NOT    |
+      |       10       |      3      |     0.15     |  SHOULD        |
+      |       10       |      4      |     0.15     |  SHOULD        |
+      |       10       |      5      |     0.15     |  SHOULD        |
+      |       10       |      6      |     0.15     |  SHOULD        |
+      |       10       |      7      |     0.15     |  SHOULD        |
+      |       10       |      8      |     0.15     |  SHOULD        |
+      |       10       |      9      |     0.15     |  SHOULD        |
+      |       10       |     10      |     0.15     |  SHOULD        |
+

--- a/application/features/sync.feature
+++ b/application/features/sync.feature
@@ -184,16 +184,27 @@ Feature: Synchronizing records
         | 10002          | Original 2     | person_two   | p2@example.com | yes    |
         | 10003          | Changed 3      | person_three | p3@example.com | yes    |
 
-  Scenario: Aborting a sync if too many users will be deactivated
-    Given 10 users are active in the ID Broker
-      And only 5 users are active in the ID Store
-      And the cutoff for deactivations is 10%
+  Scenario Outline: Preventing too many user-deactivations at a time
+    Given <brokerHas> users are active in the ID Broker
+      And only <storeOnlyHas> users are active in the ID Store
+      And the cutoff for deactivations is <cutoffPercent>%
     When I sync all the users from the ID Store to the ID Broker
-    Then an exception SHOULD have been thrown
+    Then an exception <exceptionOrNot> have been thrown
 
-  Scenario: Not aborting a sync when the users to be deactivated is below the threshold
-    Given 10 users are active in the ID Broker
-      And only 5 users are active in the ID Store
-      And the cutoff for deactivations is 60%
-    When I sync all the users from the ID Store to the ID Broker
-    Then an exception should NOT have been thrown
+    Examples:
+      | brokerHas | storeOnlyHas | cutoffPercent | exceptionOrNot |
+      |  10       |  10          |  15           |  should NOT    |
+      |  10       |   9          |  15           |  should NOT    |
+      |  10       |   8          |  15           |  should NOT    |
+      |  10       |   7          |  15           |  SHOULD        |
+      |  10       |   6          |  15           |  SHOULD        |
+      |  10       |   5          |  15           |  SHOULD        |
+      |  10       |   4          |  15           |  SHOULD        |
+      |  10       |   3          |  15           |  SHOULD        |
+      |  10       |   2          |  15           |  SHOULD        |
+      |  10       |   1          |  15           |  SHOULD        |
+      |  10       |   0          |  15           |  SHOULD        |
+      |  10       |   5          |  60           |  should NOT    |
+      |  10       |   4          |  60           |  should NOT    |
+      |  10       |   3          |  60           |  SHOULD        |
+      |  10       |   2          |  60           |  SHOULD        |

--- a/application/features/sync.feature
+++ b/application/features/sync.feature
@@ -187,24 +187,31 @@ Feature: Synchronizing records
   Scenario Outline: Preventing too many user-deactivations at a time
     Given <brokerHas> users are active in the ID Broker
       And only <storeOnlyHas> users are active in the ID Store
-      And the cutoff for deactivations is <cutoffPercent>%
+      And the cutoff for deactivations is <cutoffPercent>
     When I sync all the users from the ID Store to the ID Broker
     Then an exception <exceptionOrNot> have been thrown
 
     Examples:
       | brokerHas | storeOnlyHas | cutoffPercent | exceptionOrNot |
-      |  10       |  10          |  15           |  should NOT    |
-      |  10       |   9          |  15           |  should NOT    |
-      |  10       |   8          |  15           |  should NOT    |
-      |  10       |   7          |  15           |  SHOULD        |
-      |  10       |   6          |  15           |  SHOULD        |
-      |  10       |   5          |  15           |  SHOULD        |
-      |  10       |   4          |  15           |  SHOULD        |
-      |  10       |   3          |  15           |  SHOULD        |
-      |  10       |   2          |  15           |  SHOULD        |
-      |  10       |   1          |  15           |  SHOULD        |
-      |  10       |   0          |  15           |  SHOULD        |
-      |  10       |   5          |  60           |  should NOT    |
-      |  10       |   4          |  60           |  should NOT    |
-      |  10       |   3          |  60           |  SHOULD        |
-      |  10       |   2          |  60           |  SHOULD        |
+      |  10       |  10          |   0.15        |  should NOT    |
+      |  10       |   9          |   0.15        |  should NOT    |
+      |  10       |   8          |   0.15        |  should NOT    |
+      |  10       |   7          |   0.15        |  SHOULD        |
+      |  10       |   6          |   0.15        |  SHOULD        |
+      |  10       |   5          |   0.15        |  SHOULD        |
+      |  10       |   4          |   0.15        |  SHOULD        |
+      |  10       |   3          |   0.15        |  SHOULD        |
+      |  10       |   2          |   0.15        |  SHOULD        |
+      |  10       |   1          |   0.15        |  SHOULD        |
+      |  10       |   0          |   0.15        |  SHOULD        |
+      |  10       |   5          |   0.60        |  should NOT    |
+      |  10       |   4          |   0.60        |  should NOT    |
+      |  10       |   3          |   0.60        |  SHOULD        |
+      |  10       |   2          |   0.60        |  SHOULD        |
+      |   2       |   2          |  -1           |  SHOULD        |
+      |   2       |   2          |   0           |  should NOT    |
+      |   2       |   2          |   1           |  should NOT    |
+      |   2       |   2          |   0.99        |  should NOT    |
+      |   2       |   2          |   1.00        |  should NOT    |
+      |   2       |   2          |   1.01        |  SHOULD        |
+      |   2       |   2          |   abcd        |  SHOULD        |

--- a/application/features/sync.feature
+++ b/application/features/sync.feature
@@ -183,35 +183,3 @@ Feature: Synchronizing records
         | 10001          | Unchanged 1    | person_one   | p1@example.com | yes    |
         | 10002          | Original 2     | person_two   | p2@example.com | yes    |
         | 10003          | Changed 3      | person_three | p3@example.com | yes    |
-
-  Scenario Outline: Preventing too many user-deactivations at a time
-    Given <brokerHas> users are active in the ID Broker
-      And only <storeOnlyHas> users are active in the ID Store
-      And the cutoff for deactivations is <cutoffPercent>
-    When I sync all the users from the ID Store to the ID Broker
-    Then an exception <exceptionOrNot> have been thrown
-
-    Examples:
-      | brokerHas | storeOnlyHas | cutoffPercent | exceptionOrNot |
-      |  10       |  10          |   0.15        |  should NOT    |
-      |  10       |   9          |   0.15        |  should NOT    |
-      |  10       |   8          |   0.15        |  should NOT    |
-      |  10       |   7          |   0.15        |  SHOULD        |
-      |  10       |   6          |   0.15        |  SHOULD        |
-      |  10       |   5          |   0.15        |  SHOULD        |
-      |  10       |   4          |   0.15        |  SHOULD        |
-      |  10       |   3          |   0.15        |  SHOULD        |
-      |  10       |   2          |   0.15        |  SHOULD        |
-      |  10       |   1          |   0.15        |  SHOULD        |
-      |  10       |   0          |   0.15        |  SHOULD        |
-      |  10       |   5          |   0.60        |  should NOT    |
-      |  10       |   4          |   0.60        |  should NOT    |
-      |  10       |   3          |   0.60        |  SHOULD        |
-      |  10       |   2          |   0.60        |  SHOULD        |
-      |   2       |   2          |  -1           |  SHOULD        |
-      |   2       |   2          |   0           |  should NOT    |
-      |   2       |   2          |   1           |  should NOT    |
-      |   2       |   2          |   0.99        |  should NOT    |
-      |   2       |   2          |   1.00        |  should NOT    |
-      |   2       |   2          |   1.01        |  SHOULD        |
-      |   2       |   2          |   abcd        |  SHOULD        |

--- a/application/features/sync.feature
+++ b/application/features/sync.feature
@@ -46,7 +46,8 @@ Feature: Synchronizing records
         | employee_id    | display_name | username   | active |
         | 10001          | First Last   | first_last | yes    |
     When I sync all the users from the ID Store to the ID Broker
-    Then ONLY the following users should exist in the ID Broker:
+    Then an exception should NOT have been thrown
+      And ONLY the following users should exist in the ID Broker:
         | employee_id    | display_name | username   | active |
         | 10001          | Nickname     | first_last | yes    |
 
@@ -59,7 +60,8 @@ Feature: Synchronizing records
         | employee_id    | display_name | username   | active |
         | 10001          | Person One   | person_one | yes    |
     When I sync all the users from the ID Store to the ID Broker
-    Then ONLY the following users should exist in the ID Broker:
+    Then an exception should NOT have been thrown
+      And ONLY the following users should exist in the ID Broker:
         | employee_id    | display_name | username   | active |
         | 10001          | Person One   | person_one | yes    |
         | 10002          | Person Two   | person_two | yes    |
@@ -69,13 +71,15 @@ Feature: Synchronizing records
       And NO users exist in the ID Broker
       And user 3 in the list from ID Store will be rejected by the ID Broker
     When I sync all the users from the ID Store to the ID Broker
-    Then the ID Broker should now have 4 active users.
+    Then an exception should NOT have been thrown
+      And the ID Broker should now have 4 active users.
 
   Scenario: Handling a sync update error gracefully
     Given 5 users are active in the ID Store and are inactive in the ID Broker
       And user 3 in the list from ID Store will be rejected by the ID Broker
     When I sync all the users from the ID Store to the ID Broker
-    Then the ID Broker should now have 4 active users.
+    Then an exception should NOT have been thrown
+      And the ID Broker should now have 4 active users.
 
   Scenario: Handling sync errors gracefully (in more detail)
     Given ONLY the following users are active in the ID Store:
@@ -89,7 +93,8 @@ Feature: Synchronizing records
         | 10001          | One to Update   | person_one   | p1@example.com | yes    |
         | 10003          | Three to Update | person_three | p3@example.com | yes    |
     When I sync all the users from the ID Store to the ID Broker
-    Then ONLY the following users should exist in the ID Broker:
+    Then an exception should NOT have been thrown
+      And ONLY the following users should exist in the ID Broker:
         | employee_id    | display_name    | username     | email          | active |
         | 10001          | Good Update     | person_one   | p1@example.com | yes    |
         | 10003          | Three to Update | person_three | p3@example.com | yes    |
@@ -105,7 +110,8 @@ Feature: Synchronizing records
         | 10001          | Person One   | person_one | yes    |
         | 10002          | Person Two   | person_two | no     |
     When I sync all the users from the ID Store to the ID Broker
-    Then ONLY the following users should exist in the ID Broker:
+    Then an exception should NOT have been thrown
+      And ONLY the following users should exist in the ID Broker:
         | employee_id    | display_name | username   | active |
         | 10001          | Person One   | person_one | yes    |
         | 10002          | Person Two   | person_two | yes    |
@@ -120,7 +126,8 @@ Feature: Synchronizing records
         | 10002          | Person Two   | person_two   | yes    |
         | 10003          | Person Three | person_three | no     |
     When I sync all the users from the ID Store to the ID Broker
-    Then ONLY the following users should exist in the ID Broker:
+    Then an exception should NOT have been thrown
+      And ONLY the following users should exist in the ID Broker:
         | employee_id    | display_name | username     | active |
         | 10001          | Person One   | person_one   | no     |
         | 10002          | Person Two   | person_two   | yes    |
@@ -176,3 +183,17 @@ Feature: Synchronizing records
         | 10001          | Unchanged 1    | person_one   | p1@example.com | yes    |
         | 10002          | Original 2     | person_two   | p2@example.com | yes    |
         | 10003          | Changed 3      | person_three | p3@example.com | yes    |
+
+  Scenario: Aborting a sync if too many users will be deactivated
+    Given 10 users are active in the ID Broker
+      And only 5 users are active in the ID Store
+      And the cutoff for deactivations is 10%
+    When I sync all the users from the ID Store to the ID Broker
+    Then an exception SHOULD have been thrown
+
+  Scenario: Not aborting a sync when the users to be deactivated is below the threshold
+    Given 10 users are active in the ID Broker
+      And only 5 users are active in the ID Store
+      And the cutoff for deactivations is 60%
+    When I sync all the users from the ID Store to the ID Broker
+    Then an exception should NOT have been thrown


### PR DESCRIPTION
This puts the safety cutoff in place for preventing too many deactivations, updates, or additions.

For a full sync, the cutoff is applied to each operation (create and deactivate) separately. Since we aren't comparing values to know whether a user found in both the ID Broker and the ID Store actually needs to be updated, we can't really limit the number of updates that a full sync does (since all users found in both places will be updated).

For an incremental sync, we're simply given a list of Employee IDs. If that total is more than our safety cutoff, we abort (rather than tallying up separate counts for each type of operation).