### PR TITLE
Prefer IdP display name

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -10,6 +10,7 @@ use yii\swiftmailer\Mailer;
 
 $appEnv = Env::get('APP_ENV', 'prod'); // Have default match "application/frontend/web/index.php".
 $idpName = Env::requireEnv('IDP_NAME');
+$idpDisplayName = Env::get('IDP_DISPLAY_NAME', $idpName);
 
 $idBrokerOptionalConfig = Env::getArrayFromPrefix('ID_BROKER_CONFIG_');
 $idStoreOptionalConfig = Env::getArrayFromPrefix('ID_STORE_CONFIG_');
@@ -72,7 +73,7 @@ return [
              */
             'emailTo' => Env::get('NOTIFIER_EMAIL_TO'),
             'emailFrom' => Env::get('MAILER_USERNAME'),
-            'organizationName' => $idpName,
+            'organizationName' => $idpDisplayName,
         ],
     ],
 ];

--- a/local.env.dist
+++ b/local.env.dist
@@ -1,7 +1,7 @@
 ### Required ENV vars ###
 
-# The user-friendly version of the name of this IdP.
-# Example: "Your Org"
+# The code name of this IdP (lowercased, hyphens if needed).
+# Example: "acme"
 IDP_NAME=
 
 # The ID Broker adapter to use. See IdBrokerBase::ADAPTER_* constants for
@@ -43,6 +43,10 @@ ID_SYNC_ACCESS_TOKENS=
 
 ## [prod|dev|test], app defaults to prod
 #APP_ENV=
+
+# The user-friendly version of the name of this IdP.
+# Example: "Acme"
+IDP_DISPLAY_NAME=
 
 ## Email notification config. Do not provide a NOTIFIER_EMAIL_TO email address if
 ## you do not want to send notification emails.


### PR DESCRIPTION
This is for the HR notification emails send by ID Sync (with the list of accounts that lack an email address).