### PR TITLE
Workday ID Store adapter

### DIFF
--- a/application/common/components/IdStoreBase.php
+++ b/application/common/components/IdStoreBase.php
@@ -3,6 +3,7 @@ namespace Sil\Idp\IdSync\common\components;
 
 use Sil\Idp\IdSync\common\components\adapters\GoogleSheetsIdStore;
 use Sil\Idp\IdSync\common\components\adapters\InsiteIdStore;
+use Sil\Idp\IdSync\common\components\adapters\WorkdayIdStore;
 use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdStore;
 use Sil\Idp\IdSync\common\interfaces\IdStoreInterface;
 use Sil\Idp\IdSync\common\models\User;
@@ -13,11 +14,13 @@ abstract class IdStoreBase extends Component implements IdStoreInterface
     const ADAPTER_FAKE = 'fake';
     const ADAPTER_GOOGLE_SHEETS = 'googlesheets';
     const ADAPTER_INSITE = 'insite';
+    const ADAPTER_WORKDAY = 'workday';
     
     protected static $adapters = [
         self::ADAPTER_FAKE => FakeIdStore::class,
         self::ADAPTER_GOOGLE_SHEETS => GoogleSheetsIdStore::class,
         self::ADAPTER_INSITE => InsiteIdStore::class,
+        self::ADAPTER_WORKDAY => WorkdayIdStore::class,
     ];
     
     public static function getAdapterClassFor($adapterName)

--- a/application/common/components/IdStoreBase.php
+++ b/application/common/components/IdStoreBase.php
@@ -70,10 +70,17 @@ abstract class IdStoreBase extends Component implements IdStoreInterface
      */
     abstract public static function getIdBrokerFieldNames();
     
+    /**
+     * Get the ID Broker field name corresponding to the given ID Store field
+     * name. If there is no such ID Broker field, return null.
+     *
+     * @param string $idStoreFieldName
+     * @return string|null
+     */
     protected static function getIdBrokerFieldNameFor(string $idStoreFieldName)
     {
         $idBrokerFieldNames = static::getIdBrokerFieldNames();
-        return $idBrokerFieldNames[$idStoreFieldName];
+        return $idBrokerFieldNames[$idStoreFieldName] ?? null;
     }
     
     /**
@@ -90,7 +97,9 @@ abstract class IdStoreBase extends Component implements IdStoreInterface
         
         foreach ($userFromIdStore as $idStoreFieldName => $value) {
             $idBrokerFieldName = self::getIdBrokerFieldNameFor($idStoreFieldName);
-            $userForIdBroker[$idBrokerFieldName] = $value;
+            if ($idBrokerFieldName !== null) {
+                $userForIdBroker[$idBrokerFieldName] = $value;
+            }
         }
         
         return $userForIdBroker;

--- a/application/common/components/adapters/WorkdayIdStore.php
+++ b/application/common/components/adapters/WorkdayIdStore.php
@@ -1,0 +1,148 @@
+<?php
+namespace Sil\Idp\IdSync\common\components\adapters;
+
+use Exception;
+use GuzzleHttp\Client;
+use InvalidArgumentException;
+use Sil\Idp\IdSync\common\components\IdStoreBase;
+use Sil\Idp\IdSync\common\models\User;
+use yii\helpers\Json;
+
+class WorkdayIdStore extends IdStoreBase
+{
+    public $apiUrl = null;
+    public $username = null;
+    public $password = null;
+    
+    public $timeout = 45; // Timeout in seconds (per call to ID Store API).
+    
+    protected $httpClient = null;
+    
+    public function init()
+    {
+        $requiredProperties = [
+            'apiUrl',
+            'username',
+            'password',
+        ];
+        foreach ($requiredProperties as $requiredProperty) {
+            if (empty($this->$requiredProperty)) {
+                throw new InvalidArgumentException(sprintf(
+                    'No %s was provided.',
+                    $requiredProperty
+                ), 1532982562);
+            }
+        }
+        
+        parent::init();
+    }
+    
+    public static function getIdBrokerFieldNames()
+    {
+        return [
+            'Employee_Number' => User::EMPLOYEE_ID,
+            'First_Name' => User::FIRST_NAME,
+            'Last_Name' => User::LAST_NAME,
+            'Display_Name' => User::DISPLAY_NAME,
+            'Email' => User::EMAIL,
+            'Username' => User::USERNAME,
+            'Account_Locked__Disabled_or_Expired' => User::LOCKED,
+            //'' => User::REQUIRE_MFA, /** @todo Insert correct field name */
+            //'' => User::MANAGER_EMAIL, /** @todo Insert correct field name */
+            'Spouse_Email_Work' => User::SPOUSE_EMAIL,
+            // No 'active' needed, since all ID Store records returned are active.
+        ];
+    }
+    
+    /**
+     * Get the specified user's information. Note that inactive users will be
+     * treated as non-existent users.
+     *
+     * @param string $employeeId The Employee ID.
+     * @return User|null Information about the specified user, or null if no
+     *     such active user was found.
+     * @throws Exception
+     */
+    public function getActiveUser(string $employeeId)
+    {
+        throw new \Exception(__FUNCTION__ . ' not yet implemented');
+    }
+    
+    /**
+     * Get a list of users' information (containing at least an Employee ID) for
+     * all users changed since the specified time.
+     *
+     * @param int $unixTimestamp The time (as a UNIX timestamp).
+     * @return User[]
+     * @throws Exception
+     */
+    public function getUsersChangedSince(int $unixTimestamp): array
+    {
+        throw new Exception(__FUNCTION__ . ' not yet implemented');
+    }
+    
+    public function getAllActiveUsers(): array
+    {
+        $response = $this->getHttpClient()->get($this->apiUrl, [
+            'auth' => [$this->username, $this->password, 'basic'],
+            'connect_timeout' => $this->timeout,
+            'headers' => [
+                'Accept' => 'application/json',
+                'Accept-Encoding' => 'gzip',
+            ],
+            'http_errors' => false,
+        ]);
+    
+        $statusCode = (int)$response->getStatusCode();
+        if ($statusCode === 404) {
+            $allActiveUsers = null;
+        } elseif (($statusCode >= 200) && ($statusCode <= 299)) {
+            $data = Json::decode($response->getBody());
+            $allActiveUsers = $data['items'] ?? null;
+        } else {
+            throw new Exception(sprintf(
+                'Unexpected response (%s %s): %s',
+                $response->getStatusCode(),
+                $response->getReasonPhrase(),
+                $response->getBody()
+            ), 1533069498);
+        }
+        
+        if (! is_array($allActiveUsers)) {
+            throw new Exception(sprintf(
+                'Unexpected result when getting all active users: %s',
+                var_export($allActiveUsers, true)
+            ), 1532982679);
+        }
+        return self::getAsUsers($allActiveUsers);
+    }
+    
+//    /**
+//     * Call the ID Store API itself.
+//     *
+//     * @return array|null The resulting data, or null if unavailable (such as
+//     *     with a 404 response, or if the list of results was not returned).
+//     * @throws Exception
+//     */
+//    protected function getFromIdStore()
+//    {
+//    }
+    
+    /**
+     * Get the HTTP client to use.
+     *
+     * @return Client
+     */
+    protected function getHttpClient()
+    {
+        if ($this->httpClient === null) {
+            $this->httpClient = new Client();
+        }
+        return $this->httpClient;
+    }
+
+    public function getIdStoreName(): string
+    {
+        return 'Workday';
+    }
+}

--- a/application/common/components/adapters/WorkdayIdStore.php
+++ b/application/common/components/adapters/WorkdayIdStore.php
@@ -76,12 +76,12 @@ class WorkdayIdStore extends IdStoreBase
      * @return User[]
      * @throws Exception
      */
-    public function getUsersChangedSince(int $unixTimestamp): array
+    public function getUsersChangedSince(int $unixTimestamp)
     {
         throw new Exception(__FUNCTION__ . ' not yet implemented');
     }
     
-    public function getAllActiveUsers(): array
+    public function getAllActiveUsers()
     {
         $response = $this->getHttpClient()->get($this->apiUrl, [
             'auth' => [$this->username, $this->password, 'basic'],

--- a/application/common/components/adapters/WorkdayIdStore.php
+++ b/application/common/components/adapters/WorkdayIdStore.php
@@ -47,8 +47,8 @@ class WorkdayIdStore extends IdStoreBase
             'Email' => User::EMAIL,
             'Username' => User::USERNAME,
             'Account_Locked__Disabled_or_Expired' => User::LOCKED,
-            //'' => User::REQUIRE_MFA, /** @todo Insert correct field name */
-            //'' => User::MANAGER_EMAIL, /** @todo Insert correct field name */
+            'requireMfa' => User::REQUIRE_MFA,
+            'Manager_Email' => User::MANAGER_EMAIL,
             'Spouse_Email_Work' => User::SPOUSE_EMAIL,
             // No 'active' needed, since all ID Store records returned are active.
         ];

--- a/application/common/components/adapters/WorkdayIdStore.php
+++ b/application/common/components/adapters/WorkdayIdStore.php
@@ -65,7 +65,7 @@ class WorkdayIdStore extends IdStoreBase
      */
     public function getActiveUser(string $employeeId)
     {
-        throw new \Exception(__FUNCTION__ . ' not yet implemented');
+        throw new Exception(__FUNCTION__ . ' not yet implemented');
     }
     
     /**
@@ -81,6 +81,12 @@ class WorkdayIdStore extends IdStoreBase
         throw new Exception(__FUNCTION__ . ' not yet implemented');
     }
     
+    /**
+     * Get information about each of the (active) users.
+     *
+     * @return User[] A list of Users.
+     * @throws Exception
+     */
     public function getAllActiveUsers()
     {
         $response = $this->getHttpClient()->get($this->apiUrl, [
@@ -92,7 +98,7 @@ class WorkdayIdStore extends IdStoreBase
             ],
             'http_errors' => false,
         ]);
-    
+        
         $statusCode = (int)$response->getStatusCode();
         if ($statusCode === 404) {
             $allActiveUsers = null;
@@ -117,17 +123,6 @@ class WorkdayIdStore extends IdStoreBase
         return self::getAsUsers($allActiveUsers);
     }
     
-//    /**
-//     * Call the ID Store API itself.
-//     *
-//     * @return array|null The resulting data, or null if unavailable (such as
-//     *     with a 404 response, or if the list of results was not returned).
-//     * @throws Exception
-//     */
-//    protected function getFromIdStore()
-//    {
-//    }
-    
     /**
      * Get the HTTP client to use.
      *
@@ -140,7 +135,7 @@ class WorkdayIdStore extends IdStoreBase
         }
         return $this->httpClient;
     }
-
+    
     public function getIdStoreName(): string
     {
         return 'Workday';

--- a/application/common/components/adapters/WorkdayIdStore.php
+++ b/application/common/components/adapters/WorkdayIdStore.php
@@ -104,7 +104,7 @@ class WorkdayIdStore extends IdStoreBase
             $allActiveUsers = null;
         } elseif (($statusCode >= 200) && ($statusCode <= 299)) {
             $data = Json::decode($response->getBody());
-            $allActiveUsers = $data['items'] ?? null;
+            $allActiveUsers = $data['Report_Entry'] ?? null;
         } else {
             throw new Exception(sprintf(
                 'Unexpected response (%s %s): %s',

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -175,7 +175,7 @@ class User
         
         $lowercasedValue = strtolower(trim($value));
         
-        return in_array($lowercasedValue, ['true', 'yes'], true);
+        return in_array($lowercasedValue, ['true', 'yes', '1'], true);
     }
     
     protected function setLocked($input)

--- a/application/features/behat.yml
+++ b/application/features/behat.yml
@@ -21,3 +21,8 @@ default:
         webhook_features:
             paths:    [ %paths.base%/../features/webhook.feature ]
             contexts: [ Sil\Idp\IdSync\Behat\Context\WebhookContext ]
+        workday_integration_features:
+            filters:
+                tags: '@allUsers'
+            paths:    [ %paths.base%/../features/id-store-integration.feature ]
+            contexts: [ Sil\Idp\IdSync\Behat\Context\WorkdayIntegrationContext ]

--- a/application/features/bootstrap/UserContext.php
+++ b/application/features/bootstrap/UserContext.php
@@ -34,13 +34,21 @@ class UserContext implements Context
     {
         $this->user = $this->createUserWith($field, $input);
     }
+    
+    /**
+     * @Given I create a User with a :field value of 0
+     */
+    public function iCreateAUserWithAValueOf0($field)
+    {
+        $this->user = $this->createUserWith($field, 0);
+    }
 
     /**
-     * @Given /^I create a User with a ([^ ]+) value of (\d+)$/
+     * @Given I create a User with a :field value of 1
      */
-    public function iCreateAUserWithAValueOfNumber($field, $number)
+    public function iCreateAUserWithAValueOf1($field)
     {
-        $this->user = $this->createUserWith($field, $number);
+        $this->user = $this->createUserWith($field, 1);
     }
 
     /**

--- a/application/features/bootstrap/UserContext.php
+++ b/application/features/bootstrap/UserContext.php
@@ -36,6 +36,14 @@ class UserContext implements Context
     }
 
     /**
+     * @Given /^I create a User with a ([^ ]+) value of (\d+)$/
+     */
+    public function iCreateAUserWithAValueOfNumber($field, $number)
+    {
+        $this->user = $this->createUserWith($field, $number);
+    }
+
+    /**
      * @When I get the info from that User
      */
     public function iGetTheInfoFromThatUser()

--- a/application/features/bootstrap/WorkdayIntegrationContext.php
+++ b/application/features/bootstrap/WorkdayIntegrationContext.php
@@ -1,0 +1,42 @@
+<?php
+namespace Sil\Idp\IdSync\Behat\Context;
+
+use Sil\Idp\IdSync\common\components\adapters\WorkdayIdStore;
+use Sil\PhpEnv\Env;
+
+/**
+ * Defines application features from the specific context.
+ */
+class WorkdayIntegrationContext extends IdStoreIntegrationContextBase
+{
+    public function __construct()
+    {
+        echo 'Testing integration with Workday.' . PHP_EOL;
+        parent::__construct();
+    }
+    
+    /**
+     * @Given I can make authenticated calls to the ID Store
+     */
+    public function iCanMakeAuthenticatedCallsToTheIdStore()
+    {
+        $workdayApiUrl = Env::requireEnv('TEST_WORKDAY_CONFIG_apiUrl');
+        $workdayUsername = Env::requireEnv('TEST_WORKDAY_CONFIG_username');
+        $workdayPassword = Env::requireEnv('TEST_WORKDAY_CONFIG_password');
+        
+        $this->idStore = new WorkdayIdStore([
+            'apiUrl' => $workdayApiUrl,
+            'username' => $workdayUsername,
+            'password' => $workdayPassword,
+        ]);
+    }
+    
+    /**
+     * @When I ask the ID Store for a specific active user
+     */
+    public function iAskTheIdStoreForASpecificActiveUser()
+    {
+        $this->activeEmployeeId = Env::requireEnv('TEST_WORKDAY_EMPLOYEE_ID');
+        $this->result = $this->idStore->getActiveUser($this->activeEmployeeId);
+    }
+}

--- a/application/features/id-store-integration.feature
+++ b/application/features/id-store-integration.feature
@@ -1,19 +1,19 @@
 
 Feature: Integration with a live ID Store
 
-  @integration
+  @integration @specificUser
   Scenario: Asking for a specific (active) user
     Given I can make authenticated calls to the ID Store
     When I ask the ID Store for a specific active user
     Then I should get back information about that user
 
-  @integration
+  @integration @allUsers
   Scenario: Asking for all (active) users
     Given I can make authenticated calls to the ID Store
     When I ask the ID Store for all active users
     Then I should get back a list of information about active users
 
-  @integration
+  @integration @usersChangedSince
   Scenario: Asking for (active) users changed since a particular time
     Given I can make authenticated calls to the ID Store
     When I ask the ID Store for all users changed since a specific point in time

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -9,24 +9,28 @@ Feature: Standardizing user info
     Examples:
       | field       | input   | output |
       | locked      | 'no'    | 'no'   |
+      | locked      | '0'     | 'no'   |
       | locked      | 'false' | 'no'   |
       | locked      | 'False' | 'no'   |
       | locked      | 'FALSE' | 'no'   |
       | locked      | false   | 'no'   |
       | locked      | 'other' | 'no'   |
       | locked      | 'yes'   | 'yes'  |
+      | locked      | '1'     | 'yes'  |
       | locked      | 'true'  | 'yes'  |
       | locked      | 'True'  | 'yes'  |
       | locked      | 'TRUE'  | 'yes'  |
       | locked      | true    | 'yes'  |
       | locked      | null    | null   |
       | require_mfa | 'no'    | 'no'   |
+      | require_mfa | '0'     | 'no'   |
       | require_mfa | 'false' | 'no'   |
       | require_mfa | 'False' | 'no'   |
       | require_mfa | 'FALSE' | 'no'   |
       | require_mfa | false   | 'no'   |
       | require_mfa | 'other' | 'no'   |
       | require_mfa | 'yes'   | 'yes'  |
+      | require_mfa | '1'     | 'yes'  |
       | require_mfa | 'true'  | 'yes'  |
       | require_mfa | 'True'  | 'yes'  |
       | require_mfa | 'TRUE'  | 'yes'  |

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -10,6 +10,7 @@ Feature: Standardizing user info
       | field       | input   | output |
       | locked      | 'no'    | 'no'   |
       | locked      | '0'     | 'no'   |
+      | locked      | 0       | 'no'   |
       | locked      | 'false' | 'no'   |
       | locked      | 'False' | 'no'   |
       | locked      | 'FALSE' | 'no'   |
@@ -17,6 +18,7 @@ Feature: Standardizing user info
       | locked      | 'other' | 'no'   |
       | locked      | 'yes'   | 'yes'  |
       | locked      | '1'     | 'yes'  |
+      | locked      | 1       | 'yes'  |
       | locked      | 'true'  | 'yes'  |
       | locked      | 'True'  | 'yes'  |
       | locked      | 'TRUE'  | 'yes'  |
@@ -24,6 +26,7 @@ Feature: Standardizing user info
       | locked      | null    | null   |
       | require_mfa | 'no'    | 'no'   |
       | require_mfa | '0'     | 'no'   |
+      | require_mfa | 0       | 'no'   |
       | require_mfa | 'false' | 'no'   |
       | require_mfa | 'False' | 'no'   |
       | require_mfa | 'FALSE' | 'no'   |
@@ -31,6 +34,7 @@ Feature: Standardizing user info
       | require_mfa | 'other' | 'no'   |
       | require_mfa | 'yes'   | 'yes'  |
       | require_mfa | '1'     | 'yes'  |
+      | require_mfa | 1       | 'yes'  |
       | require_mfa | 'true'  | 'yes'  |
       | require_mfa | 'True'  | 'yes'  |
       | require_mfa | 'TRUE'  | 'yes'  |

--- a/local.env.dist
+++ b/local.env.dist
@@ -31,13 +31,21 @@ ID_STORE_ADAPTER=
 ### Required values for Insite ID Store (when ID_STORE_ADAPTER=insite):
 ID_STORE_CONFIG_apiKey=
 ID_STORE_CONFIG_apiSecret=
-# The URL to the ID Store. Example: http://id-store.example.com
+
+# The URL to the ID Store.
+# Example: http://id-store.example.com
 ID_STORE_CONFIG_baseUrl=
 
 ### Required values for Google Sheets ID Store (when ID_STORE_ADAPTER=googlesheets):
 ID_STORE_CONFIG_applicationName=
 ID_STORE_CONFIG_jsonAuthFilePath=
 ID_STORE_CONFIG_spreadsheetId=
+
+#### Required values for Workday ID Store (when ID_STORE_ADAPTER=workday):
+ID_STORE_CONFIG_apiUrl=
+ID_STORE_CONFIG_username=
+ID_STORE_CONFIG_password=
+
 
 # Comma-delimited list of authorization tokens ID Sync will accept.
 # Example: abc123,def456
@@ -64,7 +72,7 @@ ID_SYNC_ACCESS_TOKENS=
 
 # The user-friendly version of the name of this IdP.
 # Example: "Acme"
-IDP_DISPLAY_NAME=
+#IDP_DISPLAY_NAME=
 
 ## Email notification config. Do not provide a NOTIFIER_EMAIL_TO email address
 ## if you do not want to send HR notification emails.
@@ -82,3 +90,7 @@ IDP_DISPLAY_NAME=
 #TEST_INSITE_CONFIG_apiSecret=
 #TEST_INSITE_CONFIG_baseUrl=
 #TEST_INSITE_EMPLOYEE_ID=
+#TEST_WORKDAY_CONFIG_apiUrl=
+#TEST_WORKDAY_CONFIG_username=
+#TEST_WORKDAY_CONFIG_password=
+#TEST_WORKDAY_EMPLOYEE_ID=


### PR DESCRIPTION
**Added:**
- ID Store adapter for Workday

**Fixed:**
- Treat `'0'` and `0` as `'no'` and treat `'1'` and `1` as `'yes'` (as values for `locked` and `require_mfa`)
- Ignore unexpected ID Store fields, rather than crashing