### PR TITLE
Specify in log messages which ID Store adapter was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added:
 - Added `groups` and `personal_email` attributes
 - Added `ALLOW_EMPTY_EMAIL` environment variable, defaults to `false`
+- Include ID store adapter name in logs
 
 ### Removed:
 - Removed `spouse_email` attribute

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -355,7 +355,10 @@ class Synchronizer
      */
     public function syncAll()
     {
-        $this->logger->info('Syncing all users...');
+        $this->logger->info(sprintf(
+            'Syncing all users... (%s)',
+            $this->idStore->getIdStoreName()
+        ));
         
         $idStoreUsers = $this->idStore->getAllActiveUsers();
         $idBrokerUserInfoByEmployeeId = $this->getAllIdBrokerUsersByEmployeeId([
@@ -534,8 +537,9 @@ class Synchronizer
     public function syncUsers(array $employeeIds)
     {
         $this->logger->info(sprintf(
-            'Syncing %s specific users...',
-            count($employeeIds)
+            'Syncing %s specific users... (%s)',
+            count($employeeIds),
+            $this->idStore->getIdStoreName()
         ));
         
         $usersWithoutEmail = [];
@@ -596,8 +600,9 @@ class Synchronizer
     public function syncUsersChangedSince($timestamp)
     {
         $this->logger->info(sprintf(
-            'Syncing users changed since %s...',
-            date($this->dateTimeFormat, $timestamp)
+            'Syncing users changed since %s... (%s)',
+            date($this->dateTimeFormat, $timestamp),
+            $this->idStore->getIdStoreName()
         ));
         
         $changedUsers = $this->idStore->getUsersChangedSince($timestamp);

--- a/application/run-full-batch.sh
+++ b/application/run-full-batch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-logger -p 1 -t batch.warning "{\"message\": \"Preparing to run ID Sync batch\", \"batch\": \"full\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\"}"
+logger -p 1 -t batch.warning "{\"message\": \"Preparing to run ID Sync batch\", \"batch\": \"full\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\", \"id_store_adapter\": \"${ID_STORE_ADAPTER}\"}"
 
 output=$(/data/yii batch/full 2>&1)
 
@@ -8,8 +8,8 @@ output=$(/data/yii batch/full 2>&1)
 rc=$?;
 if [[ $rc != 0 ]]; then
   echo $output;
-  logger -p 1 -t batch.warning "{\"message\": \"FAILED: ID Sync batch. Exit code ${rc}. Message: ${output}\", \"batch\": \"full\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\"}"
+  logger -p 1 -t batch.warning "{\"message\": \"FAILED: ID Sync batch. Exit code ${rc}. Message: ${output}\", \"batch\": \"full\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\", \"id_store_adapter\": \"${ID_STORE_ADAPTER}\"}"
   exit $rc;
 fi
 
-logger -p 1 -t batch.warning "{\"message\": \"Ran ID Sync batch\", \"batch\": \"full\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\"}"
+logger -p 1 -t batch.warning "{\"message\": \"Ran ID Sync batch\", \"batch\": \"full\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\", \"id_store_adapter\": \"${ID_STORE_ADAPTER}\"}"

--- a/application/run-incremental-batch.sh
+++ b/application/run-incremental-batch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-logger -p 1 -t batch.warning "{\"message\": \"Preparing to run ID Sync batch\", \"batch\": \"incremental\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\"}"
+logger -p 1 -t batch.warning "{\"message\": \"Preparing to run ID Sync batch\", \"batch\": \"incremental\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\", \"id_store_adapter\": \"${ID_STORE_ADAPTER}\"}"
 
 output=$(/data/yii batch/incremental 2>&1)
 
@@ -8,8 +8,8 @@ output=$(/data/yii batch/incremental 2>&1)
 rc=$?;
 if [[ $rc != 0 ]]; then
   echo $output;
-  logger -p 1 -t batch.warning "{\"message\": \"FAILED: ID Sync batch. Exit code ${rc}. Message: ${output}\", \"batch\": \"incremental\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\"}"
+  logger -p 1 -t batch.warning "{\"message\": \"FAILED: ID Sync batch. Exit code ${rc}. Message: ${output}\", \"batch\": \"incremental\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\", \"id_store_adapter\": \"${ID_STORE_ADAPTER}\"}"
   exit $rc;
 fi
 
-logger -p 1 -t batch.warning "{\"message\": \"Ran ID Sync batch\", \"batch\": \"incremental\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\"}"
+logger -p 1 -t batch.warning "{\"message\": \"Ran ID Sync batch\", \"batch\": \"incremental\", \"idp_name\": \"${IDP_NAME}\", \"app_env\": \"${APP_ENV}\", \"id_store_adapter\": \"${ID_STORE_ADAPTER}\"}"


### PR DESCRIPTION
This is to help clarify which HR system ID Sync is pulling data from, which can be useful when transitioning from an old HR system to a new one.