### PR TITLE
Ease initial sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed:
 - Removed `spouse_email` attribute
 
+### Fixed
+- Stop limiting the number of changes (in a single sync) to an essentially-empty
+  broker (e.g. when populating it for the first time)
+
 ## [2.1.1] - 2019-02-15
 ### Fixed:
 - Wait to update `last_synced` until after actually syncing.

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -336,6 +336,13 @@ class Synchronizer
     
     protected function getNumChangesAllowed($numActiveUsersInBroker)
     {
+        // If Broker is essentially empty, don't limit how many changes can be
+        // made (so that we can run a full sync of a new IdP, even if an
+        // incremental sync has happened).
+        if ($numActiveUsersInBroker < 10) {
+            return PHP_INT_MAX;
+        }
+        
         return max(
             ceil($numActiveUsersInBroker * $this->safetyCutoff),
             self::MIN_NUM_CHANGES_ALLOWED


### PR DESCRIPTION
### Fixed
- Stop limiting the number of changes (in a single sync) to an essentially-empty
  broker (e.g. when populating it for the first time)