### PR TITLE
add null check to be resilient against incomplete rows

### DIFF
--- a/application/common/components/clients/GoogleSheetsClient.php
+++ b/application/common/components/clients/GoogleSheetsClient.php
@@ -144,10 +144,10 @@ class GoogleSheetsClient extends Component
                 
                 $users[] = [
                     User::EMPLOYEE_ID => $user[0],
-                    User::FIRST_NAME => $user[1],
-                    User::LAST_NAME => $user[2],
-                    User::DISPLAY_NAME => $user[3],
-                    User::USERNAME => $user[4],
+                    User::FIRST_NAME => $this->getValueIfNonEmpty($user, 1),
+                    User::LAST_NAME => $this->getValueIfNonEmpty($user, 2),
+                    User::DISPLAY_NAME => $this->getValueIfNonEmpty($user, 3),
+                    User::USERNAME => $this->getValueIfNonEmpty($user, 4),
                     User::EMAIL => $this->getValueIfNonEmpty($user, 5),
                     User::ACTIVE => $user[6] ?? 'yes',
                     User::LOCKED => $user[7] ?? 'no',


### PR DESCRIPTION
When reading data from Google Sheets, handle empty cells so that an incomplete line doesn't abort the sync. I saw this happen when someone started a new line with only an id, which quite effectively disabled all sync activity.