### PR TITLE
new Workday groups config option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,11 @@ psr2:
 
 # NOTE: When running tests locally, make sure you don't exclude the integration
 #       tests (which we do when testing on Codeship).
-test: deps app broker
+test: deps unittest app broker
 	sleep 15 && make behat
 
 testci: deps app broker
 	docker-compose run --rm cli bash -c "./run-tests.sh"
+
+unittest:
+	docker-compose run --rm cli vendor/bin/phpunit

--- a/application/check-psr2.sh
+++ b/application/check-psr2.sh
@@ -2,7 +2,7 @@
 
 # Try to install composer dev dependencies
 cd /data
-composer install --no-interaction --no-scripts
+composer install --no-interaction --no-scripts --no-progress
 
 # Check the code against PSR-2.
 vendor/bin/php-cs-fixer fix -v --dry-run --stop-on-violation --using-cache=no .

--- a/application/phpunit.xml
+++ b/application/phpunit.xml
@@ -1,0 +1,9 @@
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+    </php>
+</phpunit>

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -18,14 +18,14 @@ rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 whenavail brokerdb 3306 60 echo Waited for brokerdb
 sleep 15
 
-# Run the feature tests (skipping integration tests)
-./vendor/bin/behat --config=features/behat.yml --tags '~@integration'
+# Run the unit tests
+./vendor/bin/phpunit
 
 # If they failed, exit.
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
-# Run the unit tests
-./vendor/bin/phpunit
+# Run the feature tests (skipping integration tests)
+./vendor/bin/behat --config=features/behat.yml --tags '~@integration'
 
 # If they failed, exit.
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -2,7 +2,7 @@
 
 # Try to install composer dev dependencies
 cd /data
-composer install --no-interaction --no-scripts
+composer install --no-interaction --no-scripts --no-progress
 
 # If that failed, exit.
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -23,3 +23,9 @@ sleep 15
 
 # If they failed, exit.
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+# Run the unit tests
+./vendor/bin/phpunit
+
+# If they failed, exit.
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi

--- a/application/tests/WorkdayIdStoreTest.php
+++ b/application/tests/WorkdayIdStoreTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Sil\Idp\IdSync\tests;
+
+use Sil\Idp\IdSync\common\components\adapters\WorkdayIdStore;
+use PHPUnit\Framework\TestCase;
+
+class WorkdayIdStoreTest extends TestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+        require_once __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';
+    }
+
+    public function testGetIdStoreName()
+    {
+        $idStore = $this->getWorkdayIdStore();
+        $this->assertEquals('Workday', $idStore->getIdStoreName());
+    }
+
+    public function testGenerateGroupsListsDefault()
+    {
+        $idStore = $this->getWorkdayIdStore();
+        $users = [
+            [
+                'company_ids' => 'a b c',
+                'ou_tree' => 'd e f',
+            ],
+        ];
+        $idStore->generateGroupsLists($users);
+        $this->assertEquals('a,b,c,d,e,f', $users[0]['Groups']);
+    }
+
+    public function testGenerateGroupsListsCustom()
+    {
+        $idStore = $this->getWorkdayIdStore([
+            'groupsFields' => 'field1,field2'
+        ]);
+        $users = [
+            [
+                'field1' => 'x y z',
+                'field2' => '1 2 3',
+            ],
+        ];
+        $idStore->generateGroupsLists($users);
+        $this->assertEquals('x,y,z,1,2,3', $users[0]['Groups']);
+    }
+
+    public function testGenerateGroupsListsEmptyCompanyIDs()
+    {
+        $idStore = $this->getWorkdayIdStore();
+        $users = [
+            [
+                'company_ids' => '',
+                'ou_tree' => 'd e f',
+            ],
+        ];
+        $idStore->generateGroupsLists($users);
+        $this->assertEquals('d,e,f', $users[0]['Groups']);
+    }
+
+    public function testGenerateGroupsListsEmptyOUTree()
+    {
+        $idStore = $this->getWorkdayIdStore();
+        $users = [
+            [
+                'company_ids' => 'a b c',
+                'ou_tree' => '',
+            ],
+        ];
+        $idStore->generateGroupsLists($users);
+        $this->assertEquals('a,b,c', $users[0]['Groups']);
+    }
+
+    private function getWorkdayIdStore($config = []): WorkdayIdStore
+    {
+        return new WorkdayIdStore(array_merge($config, [
+            'apiUrl' => 'https://workday.example.com',
+            'username' => 'username',
+            'password' => 'password',
+        ]));
+    }
+}

--- a/local.env.dist
+++ b/local.env.dist
@@ -39,6 +39,10 @@ ID_STORE_ADAPTER=
 #ID_STORE_CONFIG_apiUrl=
 #ID_STORE_CONFIG_username=
 #ID_STORE_CONFIG_password=
+# `groupsFields` is a comma-delimited list of Workday fields used to create the
+# 'groups' field on the ID Broker. The content of each field is converted from
+# space-delimited to comma-delimited and merged together to form the 'groups' field.
+#ID_STORE_CONFIG_groupsFields=
 
 #### Required values for Sage People ID Store (when ID_STORE_ADAPTER=sagepeople):
 #ID_STORE_CONFIG_authUrl=


### PR DESCRIPTION
`groupsFields` is a comma-delimited list of Workday fields used to create the 'groups' field on the ID Broker. The content of each field is converted from space-delimited to comma-delimited and merged together to form the 'groups' field.