### PR TITLE
Set cli's YII_ENV based on APP_ENV env. variable

### DIFF
--- a/application/yii
+++ b/application/yii
@@ -8,8 +8,12 @@
  * @license http://www.yiiframework.com/license/
  */
 
+$appEnv = \getenv('APP_ENV');
+if ($appEnv === false) {
+  $appEnv = 'prod';
+}
 defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', \getenv('APP_ENV') || 'prod');
+defined('YII_ENV') or define('YII_ENV', $appEnv);
 
 // fcgi doesn't have STDIN and STDOUT defined by default
 defined('STDIN') or define('STDIN', fopen('php://stdin', 'r'));

--- a/application/yii
+++ b/application/yii
@@ -9,7 +9,7 @@
  */
 
 defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'dev');
+defined('YII_ENV') or define('YII_ENV', \getenv('APP_ENV') || 'prod');
 
 // fcgi doesn't have STDIN and STDOUT defined by default
 defined('STDIN') or define('STDIN', fopen('php://stdin', 'r'));


### PR DESCRIPTION
The frontend [was properly setting this](https://github.com/silinternational/idp-id-sync/blob/27fc73f331e0ee57b75400d6c48e136283dbe310/application/frontend/web/index.php#L5), but for console executions (like the cron-based sync actions), this was always defaulting to "dev", even in production environments.

I'm not using our `Sil\PhpEnv\Env` class here because the composer autoloader isn't pulled in until after this line, and I don't know the effects on Yii of me changing that here.