### PR TITLE
send new user notification email if enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Send "new user" email notification to user's HR contact upon creation in the IdP
 ### Changed
 - Renamed internal user fields from "broker" to "internal"
 - Added two new user fields: `hr_contact_name`, and `hr_contact_email`

--- a/application/common/components/notify/ConsoleNotifier.php
+++ b/application/common/components/notify/ConsoleNotifier.php
@@ -28,7 +28,7 @@ class ConsoleNotifier implements NotifierInterface
         }
         return join("\n", $outputLines) . "\n";
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -36,7 +36,7 @@ class ConsoleNotifier implements NotifierInterface
     {
         return 'No external service status to check.';
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -47,5 +47,16 @@ class ConsoleNotifier implements NotifierInterface
             count($users),
             $this->getBasicInfoAsTextList($users)
         ) . PHP_EOL;
+    }
+
+    public function sendNewUserNotice(User $user)
+    {
+        $userInfo = sprintf('Employee ID %s', $user->getEmployeeId());
+        if ($user->getUsername() !== null) {
+            $userInfo .= sprintf(' (%s)', $user->getUsername());
+        }
+        $hr = $user->getHRContactEmail();
+
+        echo sprintf("NOTIFIER: Notify %s that the following user was created: \n%s", $hr, $userInfo) . PHP_EOL;
     }
 }

--- a/application/common/components/notify/FakeEmailNotifier.php
+++ b/application/common/components/notify/FakeEmailNotifier.php
@@ -2,6 +2,7 @@
 namespace Sil\Idp\IdSync\common\components\notify;
 
 use Sil\Idp\IdSync\common\interfaces\NotifierInterface;
+use Sil\Idp\IdSync\common\models\User;
 
 class FakeEmailNotifier implements NotifierInterface
 {
@@ -31,5 +32,31 @@ class FakeEmailNotifier implements NotifierInterface
             'html_body' => 'This is the html body',
             'text_body' => 'This is the text body',
         ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendNewUserNotice(User $user)
+    {
+        $this->emailsSent[] = [
+            'to_address' => $user->getHRContactEmail(),
+            'subject' => sprintf(
+                'New user in orgName IdP (%s)',
+                $user->getEmployeeId()
+            ),
+            'html_body' => 'This is the html body',
+            'text_body' => 'This is the text body',
+        ];
+    }
+
+    public function findEmailBySubject($subject): array
+    {
+        foreach ($this->emailsSent as $email) {
+            if (str_contains($email['subject'], $subject)) {
+                return $email;
+            }
+        }
+        return [];
     }
 }

--- a/application/common/components/notify/NullNotifier.php
+++ b/application/common/components/notify/NullNotifier.php
@@ -16,8 +16,13 @@ class NullNotifier implements NotifierInterface
     {
         return 'NullNotifier, so no status to check.';
     }
-    
+
     public function sendMissingEmailNotice(array $users)
+    {
+        // noop
+    }
+
+    public function sendNewUserNotice(User $user)
     {
         // noop
     }

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -137,5 +137,6 @@ return [
     'params' => [
         'syncSafetyCutoff' => Env::get('SYNC_SAFETY_CUTOFF'),
         'allowEmptyEmail' => Env::get('ALLOW_EMPTY_EMAIL', false),
+        'enableNewUserNotification' => Env::get('ENABLE_NEW_USER_NOTIFICATION', false),
     ],
 ];

--- a/application/common/interfaces/NotifierInterface.php
+++ b/application/common/interfaces/NotifierInterface.php
@@ -18,11 +18,18 @@ interface NotifierInterface
      * @throws Exception
      */
     public function getSiteStatus();
-    
+
     /**
      * Send a notification that there are Users that lack an email address.
      *
      * @param User[] $users The list of Users.
      */
     public function sendMissingEmailNotice(array $users);
+
+    /**
+     * Send a notification when a user is created.
+     *
+     * @param User $user The new User.
+     */
+    public function sendNewUserNotice(User $user);
 }

--- a/application/common/mail/new-user.html.php
+++ b/application/common/mail/new-user.html.php
@@ -8,7 +8,7 @@ use yii\helpers\Html;
 ?>
 <h2>New 'User'</h2>
 <p>
-  The following user has just been activated in the <?= Html::encode($organizationName) ?> IdP.
+  The following user has just been created in the <?= Html::encode($organizationName) ?> IdP:
 </p>
 <ol>
     <li>

--- a/application/common/mail/new-user.html.php
+++ b/application/common/mail/new-user.html.php
@@ -1,0 +1,20 @@
+<?php
+use Sil\Idp\IdSync\common\models\User;
+use yii\helpers\Html;
+
+/* @var $organizationName string */
+/* @var $user User */
+
+?>
+<h2>New 'User'</h2>
+<p>
+  The following user has just been activated in the <?= Html::encode($organizationName) ?> IdP.
+</p>
+<ol>
+    <li>
+        Employee ID <?= Html::encode($user->getEmployeeId()) ?>
+        <?php if ($user->getUsername() !== null): ?>
+            (<?= Html::encode($user->getUsername()) ?>)
+        <?php endif; ?>
+    </li>
+</ol>

--- a/application/common/mail/new-user.text.php
+++ b/application/common/mail/new-user.text.php
@@ -1,0 +1,19 @@
+<?php
+
+use Sil\Idp\IdSync\common\models\User;
+
+/* @var $organizationName string */
+/* @var $user User */
+
+?>
+    New User
+    --------
+
+    The following user has just been activated in the <?= $organizationName ?> IdP:
+
+<?php
+    echo sprintf('Employee ID %s', $user->getEmployeeId());
+    if ($user->getUsername() !== null) {
+        echo sprintf(' (%s)', $user->getUsername());
+    }
+    echo "\n";

--- a/application/common/mail/new-user.text.php
+++ b/application/common/mail/new-user.text.php
@@ -9,7 +9,7 @@ use Sil\Idp\IdSync\common\models\User;
     New User
     --------
 
-    The following user has just been activated in the <?= $organizationName ?> IdP:
+    The following user has just been created in the <?= $organizationName ?> IdP:
 
 <?php
     echo sprintf('Employee ID %s', $user->getEmployeeId());

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -36,6 +36,9 @@ class Synchronizer
     /** @var float */
     private $safetyCutoff;
 
+    /** @var bool */
+    private $enableNewUserNotification;
+
     /**
      * Create a new Synchronizer object.
      *
@@ -53,19 +56,23 @@ class Synchronizer
      *     rounded up (so that we can always make at least 1 change, assuming
      *     this value is > 0.0 and there are any active users in ID Broker). If
      *     no value is given, a default value will be used.
+     * @param bool $enableNewUserNotification (Optional:) Enable notification
+     *     email on new user creation.
      */
     public function __construct(
         IdStoreInterface $idStore,
         IdBrokerInterface $idBroker,
         LoggerInterface $logger = null,
         NotifierInterface $notifier = null,
-        $safetyCutoff = null
+        $safetyCutoff = null,
+        bool $enableNewUserNotification = false
     ) {
         $this->idStore = $idStore;
         $this->idBroker = $idBroker;
         $this->logger = $logger ?? new NullLogger();
         $this->notifier = $notifier ?? new NullNotifier();
         $this->safetyCutoff = $safetyCutoff ?? self::SAFETY_CUTOFF_DEFAULT;
+        $this->enableNewUserNotification = $enableNewUserNotification;
 
         $this->logger->info('Safety cutoff: {value}', [
             'value' => var_export($this->safetyCutoff, true),
@@ -180,7 +187,9 @@ class Synchronizer
         $this->idBroker->createUser($user->toArray());
         $this->logger->info('Created user: ' . $user->getEmployeeId());
 
-        $this->notifier->sendNewUserNotice($user);
+        if ($this->enableNewUserNotification) {
+            $this->notifier->sendNewUserNotice($user);
+        }
     }
 
     /**

--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -179,6 +179,8 @@ class Synchronizer
     {
         $this->idBroker->createUser($user->toArray());
         $this->logger->info('Created user: ' . $user->getEmployeeId());
+
+        $this->notifier->sendNewUserNotice($user);
     }
 
     /**

--- a/application/common/traits/SyncProvider.php
+++ b/application/common/traits/SyncProvider.php
@@ -23,22 +23,25 @@ trait SyncProvider
     {
         /* @var $idStore IdStoreInterface */
         $idStore = Yii::$app->idStore;
-        
+
         /* @var $idBroker IdBrokerInterface */
         $idBroker = Yii::$app->idBroker;
-        
+
         /* @var $notifier NotifierInterface */
         $notifier = Yii::$app->notifier;
-        
+
         $logger = new Psr3Yii2Logger();
         $syncSafetyCutoff = Yii::$app->params['syncSafetyCutoff'];
-        
+
+        $enableNewUserNotification = Yii::$app->params['enableNewUserNotification'] ?? false;
+
         return new Synchronizer(
             $idStore,
             $idBroker,
             $logger,
             $notifier,
-            $syncSafetyCutoff
+            $syncSafetyCutoff,
+            $enableNewUserNotification
         );
     }
 }

--- a/application/features/bootstrap/NotificationContext.php
+++ b/application/features/bootstrap/NotificationContext.php
@@ -1,6 +1,7 @@
 <?php
 namespace Sil\Idp\IdSync\Behat\Context;
 
+use Exception;
 use PHPUnit\Framework\Assert;
 use Sil\Idp\IdSync\common\components\notify\FakeEmailNotifier;
 use Sil\Idp\IdSync\common\models\User;
@@ -97,5 +98,20 @@ class NotificationContext extends SyncContext
             $email['to_address'],
             "Email was not sent to " . $user->getHRContactEmail()
         );
+    }
+
+    /**
+     * @Given new user email notifications are :enabledOrDisabled
+     * @throws Exception
+     */
+    public function newUserEmailNotificationsAre($enabledOrDisabled)
+    {
+        if ($enabledOrDisabled === "enabled") {
+            $this->enableNewUserNotifications = true;
+        } else if ($enabledOrDisabled === "disabled") {
+            $this->enableNewUserNotifications = false;
+        } else {
+            throw new Exception("invalid option '$enabledOrDisabled' for email new user email notifications");
+        }
     }
 }

--- a/application/features/bootstrap/NotificationContext.php
+++ b/application/features/bootstrap/NotificationContext.php
@@ -108,7 +108,7 @@ class NotificationContext extends SyncContext
     {
         if ($enabledOrDisabled === "enabled") {
             $this->enableNewUserNotifications = true;
-        } else if ($enabledOrDisabled === "disabled") {
+        } elseif ($enabledOrDisabled === "disabled") {
             $this->enableNewUserNotifications = false;
         } else {
             throw new Exception("invalid option '$enabledOrDisabled' for email new user email notifications");

--- a/application/features/bootstrap/NotificationContext.php
+++ b/application/features/bootstrap/NotificationContext.php
@@ -58,4 +58,44 @@ class NotificationContext extends SyncContext
 
         $this->makeFakeIdStoreWithUser($tempIdStoreUserInfo);
     }
+
+    /**
+     * @Then the email subject contains :subject
+     */
+    public function theEmailSubjectContains($subject)
+    {
+        Assert::assertNotEmpty($this->notifier->findEmailBySubject($subject));
+    }
+
+    /**
+     * @Then an email is not sent
+     */
+    public function anEmailIsNotSent()
+    {
+        Assert::assertEmpty($this->notifier->emailsSent);
+    }
+
+    /**
+     * @Then an email with subject :subject is not sent
+     */
+    public function anEmailWithSubjectIsNotSent($subject)
+    {
+        Assert::assertEmpty($this->notifier->findEmailBySubject($subject));
+    }
+
+    /**
+     * @Then a :subject email is sent to the user's HR contact
+     */
+    public function aEmailIsSentToTheUsersHrContact($subject)
+    {
+        $email = $this->notifier->findEmailBySubject($subject);
+        Assert::assertNotEmpty($email, "No email was found with the subject: " . $subject);
+
+        $user = $this->idStore->getActiveUser($this->tempEmployeeId);
+        Assert::assertContains(
+            $user->getHRContactEmail(),
+            $email['to_address'],
+            "Email was not sent to " . $user->getHRContactEmail()
+        );
+    }
 }

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -60,7 +60,7 @@ class SyncContext implements Context
     }
 
     /**
-     * @Given a specific user exists in the ID Store
+     * @Given a specific user exists in the ID Store (with an email address)
      */
     public function aSpecificUserExistsInTheIdStore()
     {

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -41,6 +41,9 @@ class SyncContext implements Context
 
     private $tempUserChanges = [];
 
+    /** @var bool */
+    protected $enableNewUserNotifications = false;
+
     public function __construct()
     {
         $this->logger = new Psr3ConsoleLogger();
@@ -90,7 +93,9 @@ class SyncContext implements Context
             $this->idStore,
             $this->idBroker,
             $this->logger,
-            $this->notifier
+            $this->notifier,
+            Synchronizer::SAFETY_CUTOFF_DEFAULT,
+            $this->enableNewUserNotifications
         );
     }
 

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -9,6 +9,7 @@ use Psr\Log\LoggerInterface;
 use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdBroker;
 use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdStore;
 use Sil\Idp\IdSync\common\components\notify\ConsoleNotifier;
+use Sil\Idp\IdSync\common\components\notify\FakeEmailNotifier;
 use Sil\Idp\IdSync\common\interfaces\IdBrokerInterface;
 use Sil\Idp\IdSync\common\interfaces\NotifierInterface;
 use Sil\Idp\IdSync\common\models\User;
@@ -28,7 +29,7 @@ class SyncContext implements Context
     private $idBroker;
 
     /** @var FakeIdStore */
-    private $idStore;
+    protected $idStore;
 
     /** @var LoggerInterface */
     protected $logger;
@@ -36,7 +37,7 @@ class SyncContext implements Context
     /** @var NotifierInterface */
     protected $notifier;
 
-    private $tempEmployeeId;
+    protected $tempEmployeeId;
 
     private $tempUserChanges = [];
 
@@ -67,6 +68,8 @@ class SyncContext implements Context
             'firstname' => 'Person',
             'lastname' => 'One',
             'email' => 'person_one@example.com',
+            'hrname' => 'HR Person',
+            'hremail' => 'hr@example.com',
         ];
 
         $this->makeFakeIdStoreWithUser($tempIdStoreUserInfo);

--- a/application/features/notification.feature
+++ b/application/features/notification.feature
@@ -6,8 +6,23 @@ Feature: Sending notifications
     When I call the sendMissingEmailNotice function
     Then an email is sent
 
+  Scenario: Don't send missing email notification
+    Given a specific user exists in the ID Store
+      But the user does not exist in the ID Broker
+    When I get the user info from the ID Store and send it to the ID Broker
+    Then an email with subject "Email address missing" is not sent
+
   Scenario: Missing email notification
     Given a specific user exists in the ID Store without an email address
       But the user does not exist in the ID Broker
     When I get the user info from the ID Store and send it to the ID Broker
     Then an email is sent
+      And the email subject contains "Email address missing"
+
+  Scenario: New user email notification
+    Given a specific user exists in the ID Store
+      But the user does not exist in the ID Broker
+    When I get the user info from the ID Store and send it to the ID Broker
+    Then a "New user" email is sent to the user's HR contact
+
+    # TODO: ensure the new user notification can be disabled

--- a/application/features/notification.feature
+++ b/application/features/notification.feature
@@ -6,8 +6,8 @@ Feature: Sending notifications
     When I call the sendMissingEmailNotice function
     Then an email is sent
 
-  Scenario: Don't send missing email notification
-    Given a specific user exists in the ID Store
+  Scenario: Don't send missing email notification when the ID Store user has an email address
+    Given a specific user exists in the ID Store with an email address
       But the user does not exist in the ID Broker
     When I get the user info from the ID Store and send it to the ID Broker
     Then an email with subject "Email address missing" is not sent

--- a/application/features/notification.feature
+++ b/application/features/notification.feature
@@ -19,10 +19,16 @@ Feature: Sending notifications
     Then an email is sent
       And the email subject contains "Email address missing"
 
-  Scenario: New user email notification
-    Given a specific user exists in the ID Store
+  Scenario: New user email notification - enabled
+    Given new user email notifications are enabled
+      And a specific user exists in the ID Store
       But the user does not exist in the ID Broker
     When I get the user info from the ID Store and send it to the ID Broker
     Then a "New user" email is sent to the user's HR contact
 
-    # TODO: ensure the new user notification can be disabled
+  Scenario: New user email notification - disabled
+    Given new user email notifications are disabled
+      And a specific user exists in the ID Store
+      But the user does not exist in the ID Broker
+    When I get the user info from the ID Store and send it to the ID Broker
+    Then an email with subject "New user" is not sent

--- a/local.env.dist
+++ b/local.env.dist
@@ -87,6 +87,9 @@ ID_SYNC_ACCESS_TOKENS=
 # To allow creation of users with no email address, set this to 'true'
 #ALLOW_EMPTY_EMAIL=
 
+# Enable email notification to HR Contact upon creation of a new user, if set to 'true'
+#ENABLE_NEW_USER_NOTIFICATION=false
+
 #COMPOSER_AUTH=
 #SYNC_SAFETY_CUTOFF=
 


### PR DESCRIPTION
Following is HR's request:

> An OU HR contact needs to receive a notification email when one of their staff gets a new SIL IdP account. 
>
> In some OUs, the HR contact will forward the email to their OU IT, who will use this information to verify with Sherlock that the user has properly set up their 2SV, password, etc.
>
> The notification email can be similar to the kind of email that HR receives when a Google account is created for one of their staff.
>
> Two new columns will be added to the [_Workday_] Integration report so that the SIL IdP integration can know who the appropriate HR contact is (based on the HR admin of the staff's Company of assignment).
>
> - HR Contact Name
> - HR Contact Email
>
> These columns would supply the HR contact name and email address for the notification email to be sent to HR.