### PR TITLE
improved new-user email template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Fixed
+- Improved the new-user email template to be more friendly
+- Don't destroy all the Docker infrastructure on the user's dev machine in 'make clean'.
+## Changed
+- Made email configuration required.
+## Removed
+- Removed Xdebug since it is no longer readily available in the base image.
 
 ### [4.2.2] - 2022-02-14
 - Remove redundant error log entry in /site/system-status handler

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ broker:
 
 clean:
 	docker-compose kill
-	docker system prune -f
+	docker-compose rm -f
 
 deps:
 	docker-compose run --rm cli composer install --no-scripts

--- a/application/common/components/notify/EmailServiceNotifier.php
+++ b/application/common/components/notify/EmailServiceNotifier.php
@@ -137,12 +137,15 @@ class EmailServiceNotifier extends Component implements NotifierInterface
             $templateVars
         );
 
+        $name = empty($user->getDisplayName())
+            ? $user->getFirstName() . ' ' . $user->getLastName()
+            : $user->getDisplayName();
         $this->getEmailServiceClient()->email([
             'to_address' => $this->getEmailTo($user),
             'subject' => sprintf(
-                'New user in %s IdP (%s)',
+                'Created %s IDP user for %s [do not reply]',
                 $this->organizationName,
-                $user->getEmployeeId()
+                $name
             ),
             'html_body' => $htmlBody,
             'text_body' => $textBody,

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -25,12 +25,6 @@ $emailServiceConfig = Env::getArrayFromPrefix('EMAIL_SERVICE_');
 
 // Re-retrieve the validIpRanges as an array.
 $emailServiceConfig['validIpRanges'] = Env::getArray('EMAIL_SERVICE_validIpRanges');
-if (empty($alertsEmail) && empty($hrNotifierEmailTo)) {
-    $emailServiceConfig['baseUrl'] = 'x';
-    $emailServiceConfig['accessToken'] = 'x';
-    $emailServiceConfig['assertValidIp'] = false;
-    $emailServiceConfig['validIpRanges'] = '';
-}
 
 /* Configure the notifier, used to send notifications to HR (such as
  * when users lack an email address):  */

--- a/application/common/mail/new-user.html.php
+++ b/application/common/mail/new-user.html.php
@@ -6,15 +6,28 @@ use yii\helpers\Html;
 /* @var $user User */
 
 ?>
-<h2>New User</h2>
 <p>
-  The following user has just been created in the <?= Html::encode($organizationName) ?> IdP:
+  <?= Html::encode($user->getHRContactName()) ?>,
 </p>
-<ul>
-    <li>
-        Employee ID <?= Html::encode($user->getEmployeeId()) ?>
-        <?php if ($user->getUsername() !== null): ?>
-            (<?= Html::encode($user->getUsername()) ?>)
-        <?php endif; ?>
-    </li>
-</ul>
+
+<p>
+  The <?= Html::encode($organizationName) ?> IDP account you requested for
+    <?php if (empty($user->getDisplayName())) {
+    echo Html::encode($user->getFirstName() . ' ' . $user->getLastName());
+} else {
+    echo Html::encode($user->getDisplayName());
+}?>
+    (Staff ID <?= Html::encode($user->getEmployeeId()) ?>) has been created.
+    Their username is <?= Html::encode($user->getUsername()) ?>.
+</p>
+
+<p>
+  An invite message will be sent to <?= Html::encode($user->getFirstName()) ?> at
+  the following address:
+
+    <?php if (empty($user->getEmail())) {
+    echo Html::encode($user->getPersonalEmail());
+} else {
+    echo Html::encode($user->getEmail());
+}?>
+</p>

--- a/application/common/mail/new-user.html.php
+++ b/application/common/mail/new-user.html.php
@@ -31,3 +31,7 @@ use yii\helpers\Html;
     echo Html::encode($user->getEmail());
 }?>
 </p>
+
+<hr>
+
+This is an automated message.

--- a/application/common/mail/new-user.text.php
+++ b/application/common/mail/new-user.text.php
@@ -6,14 +6,19 @@ use Sil\Idp\IdSync\common\models\User;
 /* @var $user User */
 
 ?>
-    New User
-    --------
+  $user->getHRContactName(),
 
-    The following user has just been created in the <?= $organizationName ?> IdP:
+  The <?= $organizationName ?> IDP account you requested for
+  <?php if (empty($user->getDisplayName())) {
+    echo $user->getFirstName() . ' ' . $user->getLastName();
+} else {
+    echo $user->getDisplayName();
+}?> (Staff ID <?= $user->getEmployeeId() ?>)
+  has been created. Their username is <?= $user->getUsername() ?>.
 
-<?php
-    echo sprintf('Employee ID %s', $user->getEmployeeId());
-    if ($user->getUsername() !== null) {
-        echo sprintf(' (%s)', $user->getUsername());
-    }
-    echo "\n";
+  An invite message will be sent to <?= $user->getFirstName() ?> at
+  the following address: <?php if (empty($user->getEmail())) {
+    echo $user->getPersonalEmail();
+} else {
+    echo $user->getEmail();
+}?>

--- a/application/common/mail/new-user.text.php
+++ b/application/common/mail/new-user.text.php
@@ -6,7 +6,7 @@ use Sil\Idp\IdSync\common\models\User;
 /* @var $user User */
 
 ?>
-  $user->getHRContactName(),
+  <?= $user->getHRContactName() ?>,
 
   The <?= $organizationName ?> IDP account you requested for
   <?php if (empty($user->getDisplayName())) {

--- a/application/common/mail/new-user.text.php
+++ b/application/common/mail/new-user.text.php
@@ -22,3 +22,7 @@ use Sil\Idp\IdSync\common\models\User;
 } else {
     echo $user->getEmail();
 }?>
+
+--
+
+This is an automated message.

--- a/application/run.sh
+++ b/application/run.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# exit immediately if any line has non-zero exit code
+set -e
+
+# echo each line for debugging
 set -x
 
 # establish a signal handler to catch the SIGTERM from a 'docker stop'
@@ -19,11 +23,6 @@ rc=$?;
 if [[ $rc != 0 ]]; then
   echo "FAILED to start cron jobs. Exit code ${rc}. Message: ${output}"
   exit $rc;
-fi
-
-if [[ $APP_ENV == "dev" ]]; then
-    export XDEBUG_CONFIG="remote_enable=1 remote_host=${REMOTE_DEBUG_IP}"
-    apt-get -y -q install php-xdebug
 fi
 
 apache2ctl -k start -D FOREGROUND

--- a/local.env.dist
+++ b/local.env.dist
@@ -121,7 +121,3 @@ ID_SYNC_ACCESS_TOKENS=
 #TEST_SECURE_USER_CONFIG_apiKey=abc123
 #TEST_SECURE_USER_CONFIG_apiSecret=abc123
 #TEST_SECURE_USER_EMPLOYEE_ID=123456
-
-
-# (optional) IP Address of development machine. Used for Xdebug connection.
-#REMOTE_DEBUG_IP=

--- a/local.env.dist
+++ b/local.env.dist
@@ -63,7 +63,9 @@ ID_STORE_ADAPTER=
 # NOTE: To run tests, make sure "abc123" is in that list.
 ID_SYNC_ACCESS_TOKENS=
 
-### Required values IF a NOTIFIER_EMAIL_TO value (optional, below) is provided.
+### Email service configuration (Required)
+# If no emails are enabled (neither NOTIFIER_EMAIL_TO nor ALERTS_EMAIL are provided and ENABLE_NEW_USER_NOTIFICATION is
+# false) dummy values may be provided for these.
 #EMAIL_SERVICE_accessToken=
 #EMAIL_SERVICE_assertValidIp=
 #EMAIL_SERVICE_baseUrl=


### PR DESCRIPTION
## Fixed
- Improved the new-user email template to be more friendly
- Don't destroy all the Docker infrastructure on the user's dev machine in 'make clean'.
## Changed
- Made email configuration required.
## Removed
- Removed Xdebug since it is no longer readily available in the base image.