### PR TITLE
Feature/small cleanup

### DIFF
--- a/application/composer.json
+++ b/application/composer.json
@@ -16,7 +16,7 @@
     "silinternational/idp-id-broker-php-client": "^3.0.0 || ^4.0",
     "silinternational/php-array-dot-notation": "^0.1.0",
     "silinternational/php-env": "^2.1.1",
-    "silinternational/psr3-adapters": "^1.1 || ^2.0 || ^3.0",
+    "silinternational/psr3-adapters": "^2.3 || ^3.0",
     "silinternational/yii2-json-log-targets": "^2.0",
     "yiisoft/yii2": "~2.0.15",
     "yiisoft/yii2-gii": "^2.0",

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d10c8939ad67e876dd147127a9502ba",
+    "content-hash": "a582f4620eeb8c7803fa916017d6b698",
     "packages": [
         {
             "name": "bower-asset/inputmask",

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -10,7 +10,6 @@ use Psr\Log\LoggerInterface;
 use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdBroker;
 use Sil\Idp\IdSync\common\components\adapters\fakes\FakeIdStore;
 use Sil\Idp\IdSync\common\components\notify\ConsoleNotifier;
-use Sil\Idp\IdSync\common\components\notify\FakeEmailNotifier;
 use Sil\Idp\IdSync\common\interfaces\IdBrokerInterface;
 use Sil\Idp\IdSync\common\interfaces\NotifierInterface;
 use Sil\Idp\IdSync\common\models\User;

--- a/application/features/bootstrap/SyncContext.php
+++ b/application/features/bootstrap/SyncContext.php
@@ -15,7 +15,7 @@ use Sil\Idp\IdSync\common\interfaces\IdBrokerInterface;
 use Sil\Idp\IdSync\common\interfaces\NotifierInterface;
 use Sil\Idp\IdSync\common\models\User;
 use Sil\Idp\IdSync\common\sync\Synchronizer;
-use Sil\Psr3Adapters\Psr3ConsoleLogger;
+use Sil\Psr3Adapters\Psr3EchoLogger;
 use yii\helpers\Json;
 
 /**
@@ -47,7 +47,7 @@ class SyncContext implements Context
 
     public function __construct()
     {
-        $this->logger = new Psr3ConsoleLogger();
+        $this->logger = new Psr3EchoLogger();
         $this->notifier = new ConsoleNotifier();
     }
 

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -25,7 +25,7 @@ sleep 15
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 # Run the feature tests (skipping integration tests)
-./vendor/bin/behat --config=features/behat.yml --tags '~@integration'
+./vendor/bin/behat --config=features/behat.yml --tags '~@integration' --stop-on-failure
 
 # If they failed, exit.
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi


### PR DESCRIPTION
### Fixed
- Get log messages from Behat tests to show at the correct place
- Require a version of our psr3-adapters that has the desired logger
- Have the Behat tests stop on failure 
- Remove unused import

---

I realize that this will have merge conflicts once the other pending PR is merged. That's fine; we can clean up those conflicts here once that's done. I just wanted to go ahead and get these fixes PR'd so they don't get lost on my machine. :-)