### PR TITLE
If syncAll() throws an exception, make sure it gets logged and emailed

### DIFF
--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -376,6 +376,28 @@ class Synchronizer
         return is_numeric($value) && ($value >= 0.0);
     }
 
+
+    /**
+     * Do a full synchronization, requesting all users from the ID Store and
+     * updating all records in the ID Broker.
+     *
+     * If there is an exception, send out an email about it.
+     */
+    public function syncAllNotifyException()
+    {
+        try {
+            $this->syncAll();
+        } catch (Exception $e) {
+            $message = sprintf(
+                'There was an error with the sync process. Code: %s, Message: %s',
+                $e->getCode(),
+                $e->getMessage(),
+            );
+            $this->logger->error($message);
+        }
+    }
+
+
     /**
      * Do a full synchronization, requesting all users from the ID Store and
      * updating all records in the ID Broker.

--- a/application/console/controllers/BatchController.php
+++ b/application/console/controllers/BatchController.php
@@ -12,7 +12,7 @@ class BatchController extends Controller
     public function actionFull()
     {
         $synchronizer = $this->getSynchronizer();
-        $synchronizer->syncAll();
+        $synchronizer->syncAllNotifyException();
     }
 
     /**


### PR DESCRIPTION
Am I seeing this right, that every `error` log also gets sent as an email to the 
`$alertsEmail = Env::get('ALERTS_EMAIL');` config?

This is in relation to 
https://trello.com/c/M6elHO0Z/449-email-alert-for-idp-sync-failure