### PR TITLE
add a bit of context to ID Store exception

### DIFF
--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -411,7 +411,12 @@ class Synchronizer
             $this->idStore->getIdStoreName()
         ));
 
-        $idStoreUsers = $this->idStore->getAllActiveUsers();
+        try {
+            $idStoreUsers = $this->idStore->getAllActiveUsers();
+        } catch (Exception $e) {
+            throw new Exception('Failed to get active users from ID Store: ' . $e->getMessage(), 1669770777);
+        }
+
         $idBrokerUserInfoByEmployeeId = $this->getAllIdBrokerUsersByEmployeeId([
             'employee_id',
             'active',


### PR DESCRIPTION
### Fixed
- Improve error log by catching and adding to an ID Store exception.

Example error message before this change:
```
{
    "app_env": "staging",
    "idp_name": "appsdev",
    "level": "error",
    "category": "application",
    "message": [
        "There was an error with the sync process. Code: 429, Message: {",
        "  \"error\": {",
        "    \"code\": 429,",
        "    \"message\": \"Resource has been exhausted (e.g. check quota).\",",
        "    \"errors\": [",
        "      {",
        "        \"message\": \"Resource has been exhausted (e.g. check quota).\",",
        "        \"domain\": \"global\",",
        "        \"reason\": \"rateLimitExceeded\"",
        "      }",
        "    ],",
        "    \"status\": \"RESOURCE_EXHAUSTED\"",
        "  }",
        "}",
        ""
    ]
}
```