### PR TITLE
Feature/wait for broker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ behatappend:
 
 broker:
 	docker-compose up -d brokerdb brokercron broker
+	make wait_for_broker
 
 clean:
 	docker-compose kill
@@ -55,3 +56,6 @@ testci: deps broker
 
 unittest:
 	docker-compose run --rm cli vendor/bin/phpunit
+
+wait_for_broker:
+	docker-compose run --rm cli whenavail broker 80 20 echo "Broker is ready"

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ psr2:
 
 # NOTE: When running tests locally, make sure you don't exclude the integration
 #       tests (which we do when testing on Codeship).
-test: deps unittest broker
-	sleep 15 && make behat
+test: deps unittest broker behat
 
 testci: deps broker
 	docker-compose run --rm cli bash -c "./run-tests.sh"

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Copy ```local.env.dist``` to ```local.env``` and supply any necessary values.
 
 ## Testing
 
-Many of the tests depend on other containers. Before running any tests, build the full development environment using
-`make start` before running tests.
-
 ### Run all except integration tests
 
 Run `make testci`
 
 ### Run a single test suite
+
+**Note:** Before running an individual test, you might need to bring up various other containers
+needed (like "broker"), depending on which test you will run. An easy way to do that is to simply
+run `make testci` first, then use one of the following to run just a specific test.
 
 - `make bash`
 - `vendor/bin/behat --config=features/behat.yml --suite=notification_features`

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -13,7 +13,7 @@ composer install --no-interaction --no-scripts --no-progress
 # Make sure the database is ready, then wait a little bit longer so that apache
 # (in "broker") has time to come up.
 whenavail brokerdb 3306 60 echo Waited for brokerdb
-sleep 15
+whenavail broker 80 60 echo Waited for broker
 
 # Run the unit tests
 ./vendor/bin/phpunit


### PR DESCRIPTION
### Fixed
- Wait for Broker to be ready (in local development) before using it
- Only wait until Broker is actually ready (rather than always 15 seconds)
- Update the README instructions re: running tests

---

### Feature PR Checklist
- [x] Documentation (README, etc.)
- [x] Run `make composershow`
