### PR TITLE
add an assertion in anActiveUserExists to ensure the test user is active

### DIFF
--- a/application/features/bootstrap/IdpIdBrokerIntegrationContext.php
+++ b/application/features/bootstrap/IdpIdBrokerIntegrationContext.php
@@ -65,6 +65,7 @@ class IdpIdBrokerIntegrationContext implements Context
     public function anActiveUserExists()
     {
         $newUser = $this->idBroker->createUser($this->testUserData);
+        Assert::assertTrue($newUser->getActive() === 'yes');
         Assert::assertNotNull($newUser);
     }
 


### PR DESCRIPTION

### Fixed
- Add an assertion in `anActiveUserExists` to ensure the test user is active.
