### PR TITLE
Release 5.4.4 -- Also push a {major} version tag (e.g. 6)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @silinternational/developers
+*.php @silinternational/php-devs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,8 @@
 
 ---
 
-### Feature PR Checklist
+### PR Checklist
+- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
 - [ ] Documentation (README, etc.)
 - [ ] Unit tests created or updated
 - [ ] Run `make composershow`

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -19,6 +19,7 @@ jobs:
     name: Build and Publish
     needs: tests
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,6 +48,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push Docker image to Docker Hub
         uses: docker/build-push-action@v5

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ psr2:
 	docker compose run --rm cli bash -c "vendor/bin/php-cs-fixer fix ."
 
 # NOTE: When running tests locally, make sure you don't exclude the integration
-#       tests (which we do when testing on Codeship).
+#       tests (which we do when testing on CI).
 test: deps unittest broker behat
 
 testci: deps broker

--- a/actions-services.yml
+++ b/actions-services.yml
@@ -12,7 +12,7 @@ services:
             EMAIL_SERVICE_baseUrl: http://email
             EMAIL_SERVICE_validIpRanges: 192.168.0.0/16
             ID_BROKER_ADAPTER: fake
-            ID_BROKER_CONFIG_accessToken: codeship-sync-to-broker-11111111
+            ID_BROKER_CONFIG_accessToken: ci-sync-to-broker-11111111
             ID_STORE_ADAPTER: fake
             IDP_NAME: Test
 
@@ -20,7 +20,7 @@ services:
         image: silintl/idp-id-broker:latest
         environment:
             APP_ENV: test
-            API_ACCESS_KEYS: codeship-sync-to-broker-11111111
+            API_ACCESS_KEYS: ci-sync-to-broker-11111111
             EMAIL_SERVICE_accessToken: dummy
             EMAIL_SERVICE_assertValidIp: "false"
             EMAIL_SERVICE_baseUrl: http://email

--- a/application/features/bootstrap/IdpIdBrokerIntegrationContext.php
+++ b/application/features/bootstrap/IdpIdBrokerIntegrationContext.php
@@ -65,6 +65,7 @@ class IdpIdBrokerIntegrationContext implements Context
     public function anActiveUserExists()
     {
         $newUser = $this->idBroker->createUser($this->testUserData);
+        Assert::assertTrue($newUser->getActive() === 'yes');
         Assert::assertNotNull($newUser);
     }
 


### PR DESCRIPTION
### Added
- Also push a major-version tag to image repos

### Fixed
- Add an assertion in `anActiveUserExists` to ensure the test user is active.
