### PR TITLE
Release 5.5.0 -- add Parameter Store as an alternative to AppConfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY application/ /data/
 RUN chown -R www-data:www-data \
     console/runtime/
 
-ADD https://github.com/silinternational/config-shim/releases/latest/download/config-shim.gz config-shim.gz
+ADD https://github.com/silinternational/config-shim/releases/download/v1.2.0/config-shim.gz config-shim.gz
 RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
 
 CMD ["/data/run.sh"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AWS:
 * `APP_ID` - AppConfig application ID or name
 * `CONFIG_ID` - AppConfig configuration profile ID or name
 * `ENV_ID` - AppConfig environment ID or name
-* `PARAMETER_STORE_PATH` - Parameter Store base path for this app, e.g. "/idp-pw-api/idp-name/prod"
+* `PARAMETER_STORE_PATH` - Parameter Store base path for this app, e.g. "/idp-id-sync/idp-name/prod"
 
 In addition, the AWS API requires authentication. It is best to use an access role
 such as an [ECS Task Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).

--- a/README.md
+++ b/README.md
@@ -2,25 +2,32 @@
 Tool to synchronize user records between the ID Broker and an ID Store
 
 ## Configuration
+
 By default, configuration is read from environment variables documented in the `local.env.dist`
 file. Copy this file to `local.env` and supply any necessary values.
 
-Optionally, you can define configuration in AWS AppConfig. To do this, set the following
-environment variables to point to the configuration in AWS:
+Optionally, you can define configuration in AWS Systems Manager.
+To do this, set the following environment variables to point to the configuration in
+AWS:
 
 * `AWS_REGION` - the AWS region in use
-* `APP_ID` - the application ID or name
-* `CONFIG_ID` - the configuration profile ID or name
-* `ENV_ID` - the environment ID or name
+* `APP_ID` - AppConfig application ID or name
+* `CONFIG_ID` - AppConfig configuration profile ID or name
+* `ENV_ID` - AppConfig environment ID or name
+* `PARAMETER_STORE_PATH` - Parameter Store base path for this app, e.g. "/idp-pw-api/idp-name/prod"
 
 In addition, the AWS API requires authentication. It is best to use an access role
 such as an [ECS Task Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).
 If that is not an option, you can specify an access token using the `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY` variables.
 
-The content of the configuration profile takes the form of a typical .env file, using
-`#` for comments and `=` for variable assignment. Any variables read from AppConfig
-will overwrite variables set in the execution environment.
+If `PARAMETER_STORE_PATH` is given, AWS Parameter Store will be used. Each parameter in AWS Parameter
+Store is set as an environment variable in the execution environment.
+
+If `PARAMETER_STORE_PATH` is not given but the AppConfig variables are, AWS AppConfig will be used.
+The content of the AppConfig configuration profile takes the form of a typical .env file, using `#`
+for comments and `=` for variable assignment. Any variables read from AppConfig will overwrite variables
+set in the execution environment.
 
 ## Testing
 

--- a/application/run.sh
+++ b/application/run.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-if [[ -z "${APP_ID}" ]]; then
-  /data/yii batch/full
-else
+if [[ $PARAMETER_STORE_PATH ]]; then
+  config-shim --path $PARAMETER_STORE_PATH /data/yii batch/full
+elif [[ $APP_ID ]]; then
   config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID /data/yii batch/full
+else
+  /data/yii batch/full
 fi


### PR DESCRIPTION
### Added
- Added Parameter Store as an alternative to AppConfig

---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] Documentation (README, etc.)
- [x] ~Unit tests created or updated~
- [x] ~Run `make composershow`~
