### PR TITLE
Release 5.5.1 -- use config-shim from base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,4 @@ COPY application/ /data/
 RUN chown -R www-data:www-data \
     console/runtime/
 
-ADD https://github.com/silinternational/config-shim/releases/download/v1.2.0/config-shim.gz config-shim.gz
-RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
-
 CMD ["/data/run.sh"]


### PR DESCRIPTION

### Removed
- Removed config-shim from Dockerfile to use the version in the silintl/php8 base image


### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] ~Documentation (README, etc.)~
- [x] ~Unit tests created or updated~
- [x] ~Run `make composershow`~
