### PR TITLE
upgrade GitHub actions

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -11,7 +11,7 @@ jobs:
       COMPOSER_CACHE_DIR: /composer
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check PSR2
         run: make psr2
       - name: Run unit tests
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -45,7 +45,7 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Build and push Docker image to GitHub Container Registry
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
[ITSE-2562 Upgrade GitHub Action steps that are using Node 20](https://support.gtis.sil.org/issue/ITSE-2562)

---

### Changed
- Update actions version references to latest available to include support for Node 24.