### PR TITLE
Release 6.0.4 -- include personal email in the new-user email template

### DIFF
--- a/application/common/mail/new-user.html.php
+++ b/application/common/mail/new-user.html.php
@@ -1,4 +1,5 @@
 <?php
+
 use Sil\Idp\IdSync\common\models\User;
 use yii\helpers\Html;
 
@@ -23,12 +24,13 @@ use yii\helpers\Html;
 
 <p>
   An invite message will be sent to <?= Html::encode($user->getFirstName()) ?> at
-  the following address:
 
     <?php if (empty($user->getEmail())) {
         echo Html::encode($user->getPersonalEmail());
-    } else {
+    } elseif (empty($user->getPersonalEmail())) {
         echo Html::encode($user->getEmail());
+    } else {
+        echo Html::encode($user->getEmail()) . ' and ' . Html::encode($user->getPersonalEmail());
     }?>
 </p>
 

--- a/application/common/mail/new-user.text.php
+++ b/application/common/mail/new-user.text.php
@@ -17,10 +17,12 @@ use Sil\Idp\IdSync\common\models\User;
   has been created. Their username is <?= $user->getUsername() ?>.
 
   An invite message will be sent to <?= $user->getFirstName() ?> at
-  the following address: <?php if (empty($user->getEmail())) {
+  <?php if (empty($user->getEmail())) {
       echo $user->getPersonalEmail();
-  } else {
+    } elseif (empty($user->getPersonalEmail())) {
       echo $user->getEmail();
+    } else {
+      echo $user->getEmail() . ' and ' . $user->getPersonalEmail();
   }?>
 
 --


### PR DESCRIPTION
[IDP-1949](https://support.gtis.sil.org/issue/IDP-1949) Add cc option to invite email

---

### Fixed
- The new-user email template now includes the new user's personal email address to more accurately represent the actual behavior of idp-id-broker.

---

### PR Checklist

- [x] Put version number in PR title if known. Example: "Release x.y.z - Summary of changes" 
- [ ] Documentation (README, etc.)
- [ ] Unit tests created (for new code) or updated (for changed code).
- [ ] Run `make composershow` if dependencies have changed.
