### PR TITLE
log stack trace, re-throw exception to log more detail for IDP-1961

### DIFF
--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -392,6 +392,7 @@ class Synchronizer
      * updating all records in the ID Broker.
      *
      * If there is an exception, send out an email about it.
+     * @throws Exception
      */
     public function syncAllNotifyException()
     {
@@ -400,9 +401,10 @@ class Synchronizer
         } catch (Exception $e) {
             $code = $e->getCode();
             $message = sprintf(
-                'There was an error with the sync process. Code: %s, Message: %s',
+                'There was an error with the sync process. Code: %s, Message: %s, Trace: %s',
                 $code,
                 $e->getMessage(),
+                $e->getTraceAsString()
             );
 
             if ($code == 503 || $code == 504) {
@@ -410,6 +412,7 @@ class Synchronizer
             } else {
                 $this->logger->error($message);
             }
+            throw new Exception('syncAll error', $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
[IDP-1961](https://support.gtis.sil.org/issue/IDP-1961) idp-id-sync internal error

---

### Added
- Added a trace output and re-throw exception to diagnose a rare internal error.
- 
---

### PR Checklist

- [ ] Put version number in PR title if known. Example: "Release x.y.z - Summary of changes" 
- [ ] Documentation (README, etc.)
- [ ] Unit tests created (for new code) or updated (for changed code).
- [ ] Run `make composershow` if dependencies have changed.
