### PR TITLE
Use __toString to log the exception

### DIFF
--- a/application/common/sync/Synchronizer.php
+++ b/application/common/sync/Synchronizer.php
@@ -401,10 +401,9 @@ class Synchronizer
         } catch (Exception $e) {
             $code = $e->getCode();
             $message = sprintf(
-                'There was an error with the sync process. Code: %s, Message: %s, Trace: %s',
+                'There was an error with the sync process. Code: %s, Message: %s',
                 $code,
-                $e->getMessage(),
-                $e->getTraceAsString()
+                $e->__toString(),
             );
 
             if ($code == 503 || $code == 504) {


### PR DESCRIPTION
[IDP-1961](https://support.gtis.sil.org/issue/IDP-1961) idp-id-sync internal error

---

### Fixed
- Use the exception `__toString()` method to hunt down the mystery exception. The stack trace doesn't include the stack from where the exception was thrown. Hopefully, since __toString includes the file and line, it might help.